### PR TITLE
Add exhaustive test coverage: 283 tests, 0 warnings

### DIFF
--- a/Tests/VCSTests/BlobTests.swift
+++ b/Tests/VCSTests/BlobTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import VCS
+
+final class BlobTests: TempDirectoryTestCase {
+    var registry: CompressionRegistry!
+    var store: ObjectStore!
+
+    override func setUp() {
+        super.setUp()
+        registry = CompressionRegistry()
+        store = ObjectStore(repositoryPath: tempDir, compressionRegistry: registry)
+    }
+
+    // MARK: - Init
+
+    func testInitProperties() {
+        let blob = Blob(content: Data("hello".utf8), compressionStrategy: "zlib")
+        XCTAssertEqual(blob.content, Data("hello".utf8))
+        XCTAssertEqual(blob.compressionStrategy, "zlib")
+    }
+
+    func testInitEmptyContent() {
+        let blob = Blob(content: Data(), compressionStrategy: "none")
+        XCTAssertEqual(blob.content, Data())
+        XCTAssertEqual(blob.compressionStrategy, "none")
+    }
+
+    func testInitLargeContent() {
+        let largeData = Data(repeating: 0x42, count: 1_000_000)
+        let blob = Blob(content: largeData, compressionStrategy: "zlib")
+        XCTAssertEqual(blob.content.count, 1_000_000)
+    }
+
+    // MARK: - Encode
+
+    func testEncodeWithZlib() throws {
+        let blob = Blob(content: Data("hello".utf8), compressionStrategy: "zlib")
+        let encoded = try blob.encode(registry: registry)
+        let prefix = String(data: encoded.prefix(10), encoding: .utf8)!
+        XCTAssertTrue(prefix.hasPrefix("blob\nzlib\n"))
+    }
+
+    func testEncodeWithNone() throws {
+        let blob = Blob(content: Data("hello".utf8), compressionStrategy: "none")
+        let encoded = try blob.encode(registry: registry)
+        let prefix = String(data: encoded.prefix(10), encoding: .utf8)!
+        XCTAssertTrue(prefix.hasPrefix("blob\nnone\n"))
+    }
+
+    func testEncodeWithLZ4() throws {
+        let blob = Blob(content: Data("hello".utf8), compressionStrategy: "lz4")
+        let encoded = try blob.encode(registry: registry)
+        let prefix = String(data: encoded.prefix(9), encoding: .utf8)!
+        XCTAssertTrue(prefix.hasPrefix("blob\nlz4\n"))
+    }
+
+    func testEncodeWithInvalidStrategy() {
+        let blob = Blob(content: Data("hello".utf8), compressionStrategy: "nonexistent")
+        XCTAssertThrowsError(try blob.encode(registry: registry)) { error in
+            XCTAssertTrue(error is CompressionError)
+        }
+    }
+
+    // MARK: - Decode
+
+    func testDecodeValid() throws {
+        let blob = Blob(content: Data("hello".utf8), compressionStrategy: "none")
+        let encoded = try blob.encode(registry: registry)
+        let decoded = try Blob.decode(encoded, registry: registry, objectStore: store)
+        XCTAssertEqual(decoded.content, Data("hello".utf8))
+        XCTAssertEqual(decoded.compressionStrategy, "none")
+    }
+
+    func testDecodeInvalidPrefix() {
+        let data = "notblob\nzlib\ndata".data(using: .utf8)!
+        XCTAssertThrowsError(try Blob.decode(data, registry: registry, objectStore: store)) { error in
+            XCTAssertTrue(error is CompressionError, "Expected CompressionError, got \(error)")
+        }
+    }
+
+    func testDecodeNoNewlines() {
+        let data = "blobzlibdata".data(using: .utf8)!
+        XCTAssertThrowsError(try Blob.decode(data, registry: registry, objectStore: store)) { error in
+            XCTAssertTrue(error is CompressionError, "Expected CompressionError, got \(error)")
+        }
+    }
+
+    func testDecodeEmptyData() {
+        XCTAssertThrowsError(try Blob.decode(Data(), registry: registry, objectStore: store)) { error in
+            XCTAssertTrue(error is CompressionError, "Expected CompressionError, got \(error)")
+        }
+    }
+
+    func testDecodeUnknownStrategy() {
+        let data = "blob\nfakecomp\ndata".data(using: .utf8)!
+        XCTAssertThrowsError(try Blob.decode(data, registry: registry, objectStore: store)) { error in
+            XCTAssertTrue(error is CompressionError, "Expected CompressionError, got \(error)")
+        }
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripZlib() throws {
+        let content = Data("Hello, World!".utf8)
+        let blob = Blob(content: content, compressionStrategy: "zlib")
+        let encoded = try blob.encode(registry: registry)
+        let decoded = try Blob.decode(encoded, registry: registry, objectStore: store)
+        XCTAssertEqual(decoded.content, content)
+    }
+
+    func testRoundTripNone() throws {
+        let content = Data("Hello, World!".utf8)
+        let blob = Blob(content: content, compressionStrategy: "none")
+        let encoded = try blob.encode(registry: registry)
+        let decoded = try Blob.decode(encoded, registry: registry, objectStore: store)
+        XCTAssertEqual(decoded.content, content)
+    }
+
+    func testRoundTripLZ4() throws {
+        let content = Data("Hello, World!".utf8)
+        let blob = Blob(content: content, compressionStrategy: "lz4")
+        let encoded = try blob.encode(registry: registry)
+        let decoded = try Blob.decode(encoded, registry: registry, objectStore: store)
+        XCTAssertEqual(decoded.content, content)
+    }
+
+    func testRoundTripEmptyContent() throws {
+        let content = Data()
+        let blob = Blob(content: content, compressionStrategy: "none")
+        let encoded = try blob.encode(registry: registry)
+        let decoded = try Blob.decode(encoded, registry: registry, objectStore: store)
+        XCTAssertEqual(decoded.content, content)
+    }
+
+    func testRoundTripBinaryContent() throws {
+        // Binary content with newlines (0x0A) — tests BUG #2
+        let content = Data([0x00, 0x0A, 0xFF, 0x0A, 0x42, 0x0A])
+        let blob = Blob(content: content, compressionStrategy: "none")
+        let encoded = try blob.encode(registry: registry)
+        let decoded = try Blob.decode(encoded, registry: registry, objectStore: store)
+        XCTAssertEqual(decoded.content, content)
+    }
+
+    func testRoundTripLargeContent() throws {
+        // Use "none" strategy for large data to avoid zlib decompression buffer limits
+        let content = Data(repeating: 0x61, count: 100_000)
+        let blob = Blob(content: content, compressionStrategy: "none")
+        let encoded = try blob.encode(registry: registry)
+        let decoded = try Blob.decode(encoded, registry: registry, objectStore: store)
+        XCTAssertEqual(decoded.content, content)
+    }
+}

--- a/Tests/VCSTests/CommitTests.swift
+++ b/Tests/VCSTests/CommitTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import VCS
+
+final class CommitTests: XCTestCase {
+
+    // MARK: - Init: with parent
+
+    func testInitWithParent() {
+        let date = Date()
+        let commit = Commit(tree: "abc123", parent: "def456", author: "Alice", timestamp: date, message: "Initial commit")
+        XCTAssertEqual(commit.tree, "abc123")
+        XCTAssertEqual(commit.parent, "def456")
+        XCTAssertEqual(commit.author, "Alice")
+        XCTAssertEqual(commit.timestamp.timeIntervalSince1970, date.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertEqual(commit.message, "Initial commit")
+    }
+
+    // MARK: - Init: without parent (nil)
+
+    func testInitWithoutParent() {
+        let commit = Commit(tree: "abc123", parent: nil, author: "Bob", timestamp: Date(), message: "Root commit")
+        XCTAssertNil(commit.parent)
+    }
+
+    // MARK: - Init: empty message
+
+    func testInitWithEmptyMessage() {
+        let commit = Commit(tree: "aaa", parent: nil, author: "Eve", timestamp: Date(), message: "")
+        XCTAssertEqual(commit.message, "")
+    }
+
+    // MARK: - Init: long message
+
+    func testInitWithLongMessage() {
+        let longMessage = String(repeating: "a", count: 10_000)
+        let commit = Commit(tree: "bbb", parent: nil, author: "Mallory", timestamp: Date(), message: longMessage)
+        XCTAssertEqual(commit.message, longMessage)
+        XCTAssertEqual(commit.message.count, 10_000)
+    }
+
+    // MARK: - Init: unicode author
+
+    func testInitWithUnicodeAuthor() {
+        let commit = Commit(tree: "ccc", parent: nil, author: "用户🧑‍💻", timestamp: Date(), message: "unicode test")
+        XCTAssertEqual(commit.author, "用户🧑‍💻")
+    }
+
+    // MARK: - Init: empty author
+
+    func testInitWithEmptyAuthor() {
+        let commit = Commit(tree: "ddd", parent: nil, author: "", timestamp: Date(), message: "no author")
+        XCTAssertEqual(commit.author, "")
+    }
+
+    // MARK: - Init: various dates
+
+    func testInitWithDistantPast() {
+        let commit = Commit(tree: "eee", parent: nil, author: "A", timestamp: .distantPast, message: "past")
+        XCTAssertEqual(commit.timestamp, .distantPast)
+    }
+
+    func testInitWithDistantFuture() {
+        let commit = Commit(tree: "fff", parent: nil, author: "A", timestamp: .distantFuture, message: "future")
+        XCTAssertEqual(commit.timestamp, .distantFuture)
+    }
+
+    func testInitWithNow() {
+        let now = Date()
+        let commit = Commit(tree: "ggg", parent: nil, author: "A", timestamp: now, message: "now")
+        XCTAssertEqual(commit.timestamp.timeIntervalSince1970, now.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    // MARK: - encode(): verify "commit\n" prefix
+
+    func testEncodeHasCommitPrefix() throws {
+        let commit = Commit(tree: "abc", parent: nil, author: "A", timestamp: Date(), message: "m")
+        let data = try commit.encode()
+        let str = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(str.hasPrefix("commit\n"))
+    }
+
+    // MARK: - encode(): valid JSON after prefix
+
+    func testEncodeProducesValidJSONAfterPrefix() throws {
+        let commit = Commit(tree: "abc", parent: "def", author: "A", timestamp: Date(), message: "m")
+        let data = try commit.encode()
+        let parts = data.split(separator: 0x0A, maxSplits: 1, omittingEmptySubsequences: false)
+        XCTAssertEqual(parts.count, 2)
+        let jsonData = Data(parts[1])
+        let parsed = try JSONDecoder().decode(Commit.self, from: jsonData)
+        XCTAssertEqual(parsed.tree, "abc")
+        XCTAssertEqual(parsed.parent, "def")
+    }
+
+    // MARK: - encode(): nil parent in JSON
+
+    func testEncodeNilParentInJSON() throws {
+        let commit = Commit(tree: "abc", parent: nil, author: "A", timestamp: Date(), message: "m")
+        let data = try commit.encode()
+        let parts = data.split(separator: 0x0A, maxSplits: 1, omittingEmptySubsequences: false)
+        let jsonData = Data(parts[1])
+        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        XCTAssertTrue(json["parent"] is NSNull || json["parent"] == nil)
+    }
+
+    // MARK: - decode(): valid data
+
+    func testDecodeValidData() throws {
+        let commit = Commit(tree: "abc", parent: "def", author: "Alice", timestamp: Date(), message: "hello")
+        let encoded = try commit.encode()
+        let decoded = try Commit.decode(encoded)
+        XCTAssertEqual(decoded.tree, "abc")
+        XCTAssertEqual(decoded.parent, "def")
+        XCTAssertEqual(decoded.author, "Alice")
+        XCTAssertEqual(decoded.message, "hello")
+    }
+
+    // MARK: - decode(): invalid prefix
+
+    func testDecodeInvalidPrefixThrows() {
+        let badData = "blob\n{}".data(using: .utf8)!
+        XCTAssertThrowsError(try Commit.decode(badData)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Invalid commit format"), "Message was: \(msg)")
+        }
+    }
+
+    // MARK: - decode(): no newline
+
+    func testDecodeNoNewlineThrows() {
+        let badData = "commit{}".data(using: .utf8)!
+        XCTAssertThrowsError(try Commit.decode(badData)) { error in
+            guard case CompressionError.decompressionFailed = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - decode(): invalid JSON
+
+    func testDecodeInvalidJSONThrows() {
+        let badData = "commit\nnot-valid-json".data(using: .utf8)!
+        XCTAssertThrowsError(try Commit.decode(badData))
+    }
+
+    // MARK: - decode(): empty Data
+
+    func testDecodeEmptyDataThrows() {
+        XCTAssertThrowsError(try Commit.decode(Data())) { error in
+            guard case CompressionError.decompressionFailed = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Round-trip: all fields preserved with parent
+
+    func testRoundTripWithParent() throws {
+        let date = Date()
+        let original = Commit(tree: "tree123", parent: "parent456", author: "用户🧑‍💻", timestamp: date, message: "A meaningful message")
+        let encoded = try original.encode()
+        let decoded = try Commit.decode(encoded)
+        XCTAssertEqual(decoded.tree, original.tree)
+        XCTAssertEqual(decoded.parent, original.parent)
+        XCTAssertEqual(decoded.author, original.author)
+        XCTAssertEqual(decoded.message, original.message)
+        XCTAssertEqual(decoded.timestamp.timeIntervalSince1970, original.timestamp.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    // MARK: - Round-trip: without parent
+
+    func testRoundTripWithoutParent() throws {
+        let original = Commit(tree: "tree789", parent: nil, author: "Bob", timestamp: Date(), message: "root")
+        let encoded = try original.encode()
+        let decoded = try Commit.decode(encoded)
+        XCTAssertEqual(decoded.tree, original.tree)
+        XCTAssertNil(decoded.parent)
+        XCTAssertEqual(decoded.author, original.author)
+        XCTAssertEqual(decoded.message, original.message)
+    }
+
+    // MARK: - Date precision: timestamp survives encode/decode
+
+    func testDatePrecisionSurvivesRoundTrip() throws {
+        let precise = Date(timeIntervalSince1970: 1_700_000_000.123)
+        let original = Commit(tree: "t", parent: nil, author: "A", timestamp: precise, message: "m")
+        let encoded = try original.encode()
+        let decoded = try Commit.decode(encoded)
+        XCTAssertEqual(decoded.timestamp.timeIntervalSince1970, precise.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    // MARK: - Codable: direct JSONEncoder/Decoder round-trip
+
+    func testCodableDirectRoundTrip() throws {
+        let original = Commit(tree: "t1", parent: "p1", author: "Author", timestamp: Date(), message: "msg")
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        let data = try encoder.encode(original)
+        let restored = try decoder.decode(Commit.self, from: data)
+        XCTAssertEqual(restored.tree, original.tree)
+        XCTAssertEqual(restored.parent, original.parent)
+        XCTAssertEqual(restored.author, original.author)
+        XCTAssertEqual(restored.message, original.message)
+        XCTAssertEqual(restored.timestamp.timeIntervalSince1970, original.timestamp.timeIntervalSince1970, accuracy: 0.001)
+    }
+}

--- a/Tests/VCSTests/CompressionRegistryTests.swift
+++ b/Tests/VCSTests/CompressionRegistryTests.swift
@@ -1,0 +1,230 @@
+import XCTest
+@testable import VCS
+
+final class CompressionRegistryTests: XCTestCase {
+    var registry: CompressionRegistry!
+
+    override func setUp() {
+        super.setUp()
+        registry = CompressionRegistry()
+    }
+
+    // MARK: - Default Registration
+
+    func testInitRegistersZlib() {
+        XCTAssertNotNil(registry.getStrategy(byName: "zlib"))
+    }
+
+    func testInitRegistersLZ4() {
+        XCTAssertNotNil(registry.getStrategy(byName: "lz4"))
+    }
+
+    func testInitRegistersNone() {
+        XCTAssertNotNil(registry.getStrategy(byName: "none"))
+    }
+
+    func testInitRegistersJPEGHeaderStrip() {
+        XCTAssertNotNil(registry.getStrategy(byName: "jpeg-header-strip"))
+    }
+
+    func testDefaultStrategyIsZlib() {
+        XCTAssertEqual(registry.defaultStrategy, "zlib")
+    }
+
+    // MARK: - getStrategy(byName:)
+
+    func testGetStrategyByNameZlib() {
+        let strategy = registry.getStrategy(byName: "zlib")
+        XCTAssertEqual(strategy?.name, "zlib")
+    }
+
+    func testGetStrategyByNameLZ4() {
+        let strategy = registry.getStrategy(byName: "lz4")
+        XCTAssertEqual(strategy?.name, "lz4")
+    }
+
+    func testGetStrategyByNameNone() {
+        let strategy = registry.getStrategy(byName: "none")
+        XCTAssertEqual(strategy?.name, "none")
+    }
+
+    func testGetStrategyByNameJPEG() {
+        let strategy = registry.getStrategy(byName: "jpeg-header-strip")
+        XCTAssertEqual(strategy?.name, "jpeg-header-strip")
+    }
+
+    func testGetStrategyByNameInvalid() {
+        XCTAssertNil(registry.getStrategy(byName: "fake"))
+    }
+
+    func testGetStrategyByNameEmpty() {
+        XCTAssertNil(registry.getStrategy(byName: ""))
+    }
+
+    // MARK: - getStrategy(forPath:) — Text extensions → zlib
+
+    func testGetStrategyForPathTxt() {
+        XCTAssertEqual(registry.getStrategy(forPath: "file.txt").name, "zlib")
+    }
+
+    func testGetStrategyForPathMd() {
+        XCTAssertEqual(registry.getStrategy(forPath: "readme.md").name, "zlib")
+    }
+
+    func testGetStrategyForPathSwift() {
+        XCTAssertEqual(registry.getStrategy(forPath: "main.swift").name, "zlib")
+    }
+
+    func testGetStrategyForPathRs() {
+        XCTAssertEqual(registry.getStrategy(forPath: "main.rs").name, "zlib")
+    }
+
+    func testGetStrategyForPathJs() {
+        XCTAssertEqual(registry.getStrategy(forPath: "app.js").name, "zlib")
+    }
+
+    func testGetStrategyForPathTs() {
+        XCTAssertEqual(registry.getStrategy(forPath: "app.ts").name, "zlib")
+    }
+
+    func testGetStrategyForPathJson() {
+        XCTAssertEqual(registry.getStrategy(forPath: "data.json").name, "zlib")
+    }
+
+    func testGetStrategyForPathXml() {
+        XCTAssertEqual(registry.getStrategy(forPath: "data.xml").name, "zlib")
+    }
+
+    func testGetStrategyForPathHtml() {
+        XCTAssertEqual(registry.getStrategy(forPath: "index.html").name, "zlib")
+    }
+
+    func testGetStrategyForPathCss() {
+        XCTAssertEqual(registry.getStrategy(forPath: "style.css").name, "zlib")
+    }
+
+    // MARK: - getStrategy(forPath:) — Log → lz4
+
+    func testGetStrategyForPathLog() {
+        XCTAssertEqual(registry.getStrategy(forPath: "app.log").name, "lz4")
+    }
+
+    // MARK: - getStrategy(forPath:) — JPEG → jpeg-header-strip
+
+    func testGetStrategyForPathJpg() {
+        XCTAssertEqual(registry.getStrategy(forPath: "photo.jpg").name, "jpeg-header-strip")
+    }
+
+    func testGetStrategyForPathJpeg() {
+        XCTAssertEqual(registry.getStrategy(forPath: "photo.jpeg").name, "jpeg-header-strip")
+    }
+
+    // MARK: - getStrategy(forPath:) — Already compressed → none
+
+    func testGetStrategyForPathPng() {
+        XCTAssertEqual(registry.getStrategy(forPath: "image.png").name, "none")
+    }
+
+    func testGetStrategyForPathGif() {
+        XCTAssertEqual(registry.getStrategy(forPath: "anim.gif").name, "none")
+    }
+
+    func testGetStrategyForPathZip() {
+        XCTAssertEqual(registry.getStrategy(forPath: "archive.zip").name, "none")
+    }
+
+    func testGetStrategyForPathGz() {
+        XCTAssertEqual(registry.getStrategy(forPath: "file.gz").name, "none")
+    }
+
+    func testGetStrategyForPathBz2() {
+        XCTAssertEqual(registry.getStrategy(forPath: "file.bz2").name, "none")
+    }
+
+    func testGetStrategyForPathMp4() {
+        XCTAssertEqual(registry.getStrategy(forPath: "video.mp4").name, "none")
+    }
+
+    func testGetStrategyForPathMp3() {
+        XCTAssertEqual(registry.getStrategy(forPath: "audio.mp3").name, "none")
+    }
+
+    func testGetStrategyForPathPdf() {
+        XCTAssertEqual(registry.getStrategy(forPath: "doc.pdf").name, "none")
+    }
+
+    // MARK: - getStrategy(forPath:) — Unknown/no extension → default
+
+    func testGetStrategyForPathUnknownExt() {
+        XCTAssertEqual(registry.getStrategy(forPath: "file.xyz").name, "zlib")
+    }
+
+    func testGetStrategyForPathNoExtension() {
+        XCTAssertEqual(registry.getStrategy(forPath: "Makefile").name, "zlib")
+    }
+
+    func testGetStrategyForPathEmpty() {
+        XCTAssertEqual(registry.getStrategy(forPath: "").name, "zlib")
+    }
+
+    // MARK: - setCompressionForExtension
+
+    func testSetCompressionForNewExtension() {
+        registry.setCompressionForExtension("py", strategy: "lz4")
+        XCTAssertEqual(registry.getStrategy(forPath: "script.py").name, "lz4")
+    }
+
+    func testSetCompressionOverrideExisting() {
+        registry.setCompressionForExtension("txt", strategy: "lz4")
+        XCTAssertEqual(registry.getStrategy(forPath: "file.txt").name, "lz4")
+    }
+
+    func testSetCompressionCaseInsensitive() {
+        registry.setCompressionForExtension("PY", strategy: "lz4")
+        XCTAssertEqual(registry.getStrategy(forPath: "script.py").name, "lz4")
+    }
+
+    // MARK: - setCompressionForPath
+
+    func testSetCompressionForPath() {
+        registry.setCompressionForPath("special/file.txt", strategy: "none")
+        XCTAssertEqual(registry.getStrategy(forPath: "special/file.txt").name, "none")
+    }
+
+    func testPathOverridePrecedence() {
+        // Extension says zlib, path override says none
+        registry.setCompressionForPath("data.txt", strategy: "none")
+        XCTAssertEqual(registry.getStrategy(forPath: "data.txt").name, "none")
+    }
+
+    // MARK: - register
+
+    func testRegisterCustomStrategy() {
+        let custom = NoCompression()
+        // NoCompression has name "none" — but we can test retrieval
+        registry.register(custom)
+        let retrieved = registry.getStrategy(byName: "none")
+        XCTAssertTrue(retrieved === custom)
+    }
+
+    func testRegisterOverwritesExisting() {
+        let newZlib = ZlibCompression()
+        registry.register(newZlib)
+        let retrieved = registry.getStrategy(byName: "zlib")
+        XCTAssertTrue(retrieved === newZlib)
+    }
+
+    // MARK: - Default strategy fallback (BUG #8)
+
+    func testDefaultStrategyFallbackUnknown() {
+        registry.defaultStrategy = "nonexistent"
+        // Falls back to new ZlibCompression() instance
+        let strategy = registry.getStrategy(forPath: "file.xyz")
+        XCTAssertEqual(strategy.name, "zlib")
+    }
+
+    func testChangeDefaultStrategy() {
+        registry.defaultStrategy = "lz4"
+        XCTAssertEqual(registry.getStrategy(forPath: "file.xyz").name, "lz4")
+    }
+}

--- a/Tests/VCSTests/HashTests.swift
+++ b/Tests/VCSTests/HashTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import VCS
+
+final class HashTests: XCTestCase {
+
+    // MARK: - init with Data
+
+    func testInitWithEmptyData() {
+        let hash = Hash(Data())
+        XCTAssertEqual(hash.data, Data())
+        XCTAssertEqual(hash.hex, "")
+    }
+
+    func testInitWithSmallData() {
+        let hash = Hash(Data([0xAB, 0xCD]))
+        XCTAssertEqual(hash.data, Data([0xAB, 0xCD]))
+        XCTAssertEqual(hash.hex, "abcd")
+    }
+
+    func testInitWithLargeData() {
+        let largeData = Data(repeating: 0x42, count: 1_000_000)
+        let hash = Hash(largeData)
+        XCTAssertEqual(hash.data.count, 1_000_000)
+        XCTAssertEqual(hash.data, largeData)
+    }
+
+    // MARK: - init?(hex:)
+
+    func testInitHexWithValidLowercase() {
+        let hash = Hash(hex: "abcdef01")
+        XCTAssertNotNil(hash)
+        XCTAssertEqual(hash?.data, Data([0xAB, 0xCD, 0xEF, 0x01]))
+    }
+
+    func testInitHexWithValidUppercase() {
+        let hash = Hash(hex: "ABCDEF01")
+        XCTAssertNotNil(hash)
+        XCTAssertEqual(hash?.data, Data([0xAB, 0xCD, 0xEF, 0x01]))
+    }
+
+    func testInitHexWithMixedCase() {
+        let hash = Hash(hex: "aBcDeF01")
+        XCTAssertNotNil(hash)
+        XCTAssertEqual(hash?.data, Data([0xAB, 0xCD, 0xEF, 0x01]))
+    }
+
+    func testInitHexWithEmptyString() {
+        let hash = Hash(hex: "")
+        XCTAssertNotNil(hash)
+        XCTAssertEqual(hash?.data, Data())
+    }
+
+    func testInitHexWithInvalidChars() {
+        let hash = Hash(hex: "ZZZZ")
+        XCTAssertNil(hash)
+    }
+
+    func testInitHexWithPartiallyInvalidChars() {
+        let hash = Hash(hex: "ab__cd")
+        XCTAssertNil(hash)
+    }
+
+    // MARK: - hex property
+
+    func testHexRoundTrip() {
+        let original = "abcdef0123456789"
+        let hash = Hash(hex: original)
+        XCTAssertNotNil(hash)
+        XCTAssertEqual(hash?.hex, original)
+    }
+
+    func testHexOutputIsLowercase() {
+        let hash = Hash(Data([0x00, 0xFF]))
+        XCTAssertEqual(hash.hex, "00ff")
+    }
+
+    func testHexUppercaseInputProducesLowercaseOutput() {
+        let hash = Hash(hex: "AABB")
+        XCTAssertEqual(hash?.hex, "aabb")
+    }
+
+    // MARK: - description
+
+    func testDescriptionEqualsHex() {
+        let hash = Hash(Data([0xDE, 0xAD, 0xBE, 0xEF]))
+        XCTAssertEqual(hash.description, hash.hex)
+    }
+
+    func testDescriptionEqualsHexForEmpty() {
+        let hash = Hash(Data())
+        XCTAssertEqual(hash.description, hash.hex)
+        XCTAssertEqual(hash.description, "")
+    }
+
+    // MARK: - compute(Data)
+
+    func testComputeEmptyData() {
+        let hash = Hash.compute(Data())
+        XCTAssertEqual(
+            hash.hex,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+    }
+
+    func testComputeHelloData() {
+        let hash = Hash.compute(Data("hello".utf8))
+        XCTAssertEqual(
+            hash.hex,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+    }
+
+    func testComputeLargeData() {
+        let largeData = Data(repeating: 0x00, count: 1_000_000)
+        let hash = Hash.compute(largeData)
+        XCTAssertEqual(hash.data.count, 32)
+        XCTAssertFalse(hash.hex.isEmpty)
+    }
+
+    func testComputeIsDeterministic() {
+        let data = Data("determinism check".utf8)
+        let hash1 = Hash.compute(data)
+        let hash2 = Hash.compute(data)
+        XCTAssertEqual(hash1, hash2)
+        XCTAssertEqual(hash1.hex, hash2.hex)
+    }
+
+    // MARK: - compute(String)
+
+    func testComputeStringHelloMatchesDataOverload() {
+        let fromString = Hash.compute("hello")
+        let fromData = Hash.compute(Data("hello".utf8))
+        XCTAssertEqual(fromString, fromData)
+        XCTAssertEqual(fromString.hex, fromData.hex)
+    }
+
+    func testComputeEmptyString() {
+        let hash = Hash.compute("")
+        XCTAssertEqual(
+            hash.hex,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+    }
+
+    func testComputeUnicodeString() {
+        let hash = Hash.compute("你好🌍")
+        XCTAssertEqual(hash.data.count, 32)
+        // Verify it matches the Data-based overload with the same UTF-8 bytes.
+        let fromData = Hash.compute(Data("你好🌍".utf8))
+        XCTAssertEqual(hash, fromData)
+    }
+
+    // MARK: - Hashable
+
+    func testEqualHashesAreEqual() {
+        let a = Hash(Data([0x01, 0x02]))
+        let b = Hash(Data([0x01, 0x02]))
+        XCTAssertEqual(a, b)
+    }
+
+    func testDifferentHashesAreNotEqual() {
+        let a = Hash(Data([0x01, 0x02]))
+        let b = Hash(Data([0x03, 0x04]))
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testSetInsertionDeduplicates() {
+        let hash = Hash.compute("duplicate")
+        var set: Set<Hash> = []
+        set.insert(hash)
+        set.insert(hash)
+        XCTAssertEqual(set.count, 1)
+    }
+
+    func testDictionaryKeyUsage() {
+        let key = Hash.compute("key")
+        var dict: [Hash: String] = [:]
+        dict[key] = "value"
+        XCTAssertEqual(dict[key], "value")
+
+        // Lookup with an independently computed identical hash must succeed.
+        let sameKey = Hash.compute("key")
+        XCTAssertEqual(dict[sameKey], "value")
+    }
+}

--- a/Tests/VCSTests/JPEGHeaderCompressionTests.swift
+++ b/Tests/VCSTests/JPEGHeaderCompressionTests.swift
@@ -1,0 +1,865 @@
+import XCTest
+@testable import VCS
+
+final class JPEGHeaderCompressionTests: TempDirectoryTestCase {
+
+    private var jpeg: JPEGHeaderCompression!
+
+    override func setUp() {
+        super.setUp()
+        jpeg = JPEGHeaderCompression()
+    }
+
+    override func tearDown() {
+        jpeg = nil
+        super.tearDown()
+    }
+
+    // MARK: - A) compress() tests
+
+    func testCompressNotJPEGThrows() {
+        let data = Data([0x00, 0x00])
+        XCTAssertThrowsError(try jpeg.compress(data)) { error in
+            guard case CompressionError.compressionFailed(let msg) = error else {
+                return XCTFail("Expected compressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Not a valid JPEG"), "Message was: \(msg)")
+        }
+    }
+
+    func testCompressTooShortThrows() {
+        let data = Data([0xFF])
+        XCTAssertThrowsError(try jpeg.compress(data)) { error in
+            guard case CompressionError.compressionFailed(let msg) = error else {
+                return XCTFail("Expected compressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Not a valid JPEG"), "Message was: \(msg)")
+        }
+    }
+
+    func testCompressEmptyDataThrows() {
+        let data = Data()
+        XCTAssertThrowsError(try jpeg.compress(data)) { error in
+            guard case CompressionError.compressionFailed(let msg) = error else {
+                return XCTFail("Expected compressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Not a valid JPEG"), "Message was: \(msg)")
+        }
+    }
+
+    func testCompressStandardTablesProducesVersion02() throws {
+        let data = buildMinimalJPEG()
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x02)
+    }
+
+    func testCompressStandardTablesDimensionsEncoded() throws {
+        let width: UInt16 = 320
+        let height: UInt16 = 240
+        let data = buildMinimalJPEG(width: width, height: height)
+        let compressed = try jpeg.compress(data)
+
+        let encodedWidth = UInt16(compressed[1]) << 8 | UInt16(compressed[2])
+        let encodedHeight = UInt16(compressed[3]) << 8 | UInt16(compressed[4])
+        XCTAssertEqual(encodedWidth, width)
+        XCTAssertEqual(encodedHeight, height)
+    }
+
+    func testCompressCustomTablesProducesVersion04() throws {
+        let data = buildCustomQuantJPEG()
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04)
+    }
+
+    func testCompressCustomTablesHas32ByteHashAfterHeader() throws {
+        let data = buildCustomQuantJPEG()
+        let compressed = try jpeg.compress(data)
+        // Version (1) + dims (4) + hash (32) + scan data
+        XCTAssertGreaterThanOrEqual(compressed.count, 37)
+        // Hash is bytes 5..<37
+        let hashBytes = compressed[5..<37]
+        XCTAssertEqual(hashBytes.count, 32)
+    }
+
+    func testCompressSmallDimensions1x1() throws {
+        let data = buildMinimalJPEG(width: 1, height: 1)
+        let compressed = try jpeg.compress(data)
+        let w = UInt16(compressed[1]) << 8 | UInt16(compressed[2])
+        let h = UInt16(compressed[3]) << 8 | UInt16(compressed[4])
+        XCTAssertEqual(w, 1)
+        XCTAssertEqual(h, 1)
+    }
+
+    func testCompressLargeDimensions65535x65535() throws {
+        let data = buildMinimalJPEG(width: 65535, height: 65535)
+        let compressed = try jpeg.compress(data)
+        let w = UInt16(compressed[1]) << 8 | UInt16(compressed[2])
+        let h = UInt16(compressed[3]) << 8 | UInt16(compressed[4])
+        XCTAssertEqual(w, 65535)
+        XCTAssertEqual(h, 65535)
+    }
+
+    func testCompressZeroDimensions() throws {
+        let data = buildMinimalJPEG(width: 0, height: 0)
+        let compressed = try jpeg.compress(data)
+        let w = UInt16(compressed[1]) << 8 | UInt16(compressed[2])
+        let h = UInt16(compressed[3]) << 8 | UInt16(compressed[4])
+        XCTAssertEqual(w, 0)
+        XCTAssertEqual(h, 0)
+    }
+
+    func testCompressTruncatedSegmentThrows() {
+        // Build a JPEG SOI + start of a DQT marker but truncate before length can be read
+        let data = Data([0xFF, 0xD8, 0xFF, 0xDB])
+        // No length bytes follow -- position + 2 > data.count
+        XCTAssertThrowsError(try jpeg.compress(data)) { error in
+            guard case CompressionError.compressionFailed(let msg) = error else {
+                return XCTFail("Expected compressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Truncated"), "Message was: \(msg)")
+        }
+    }
+
+    func testCompressTruncatedSOFThrows() {
+        // Build a valid JPEG but with SOF segment too short for dimensions
+        var data = Data()
+        data.append(contentsOf: [0xFF, 0xD8]) // SOI
+        data.append(contentsOf: [0xFF, 0xC0]) // SOF
+        data.append(contentsOf: [0x00, 0x05]) // length = 5 (too short: need pos+7 <= count)
+        data.append(0x08) // precision
+        // Only 2 more bytes but need 4 for height+width
+        data.append(contentsOf: [0x00, 0x08])
+        XCTAssertThrowsError(try jpeg.compress(data)) { error in
+            guard case CompressionError.compressionFailed(let msg) = error else {
+                return XCTFail("Expected compressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Truncated SOF"), "Message was: \(msg)")
+        }
+    }
+
+    func testCompressNoSOFMarkerThrows() {
+        let data = buildMinimalJPEG(includeSOF: false)
+        XCTAssertThrowsError(try jpeg.compress(data)) { error in
+            guard case CompressionError.compressionFailed(let msg) = error else {
+                return XCTFail("Expected compressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Could not find"), "Message was: \(msg)")
+        }
+    }
+
+    func testCompressNoSOSMarkerThrows() {
+        let data = buildMinimalJPEG(includeSOS: false)
+        XCTAssertThrowsError(try jpeg.compress(data)) { error in
+            guard case CompressionError.compressionFailed(let msg) = error else {
+                return XCTFail("Expected compressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Could not find"), "Message was: \(msg)")
+        }
+    }
+
+    func testCompressProgressiveJPEG() throws {
+        let data = buildMinimalJPEG(width: 100, height: 200, sofMarker: 0xC2)
+        let compressed = try jpeg.compress(data)
+        let w = UInt16(compressed[1]) << 8 | UInt16(compressed[2])
+        let h = UInt16(compressed[3]) << 8 | UInt16(compressed[4])
+        XCTAssertEqual(w, 100)
+        XCTAssertEqual(h, 200)
+    }
+
+    func testCompressRSTMarkersSkipped() throws {
+        // RST markers (0xD0-0xD7) should be skipped without issue
+        let extraMarkers: [(UInt8, Data)] = [
+            (0xD0, Data()),
+            (0xD3, Data()),
+            (0xD7, Data()),
+        ]
+        let data = buildMinimalJPEG(extraMarkers: extraMarkers)
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x02)
+    }
+
+    func testCompressTEMMarkerSkipped() throws {
+        let extraMarkers: [(UInt8, Data)] = [(0x01, Data())]
+        let data = buildMinimalJPEG(extraMarkers: extraMarkers)
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x02)
+    }
+
+    func testCompressMultipleQuantTablesCaptured() throws {
+        // Standard JPEG already has 2 quant tables; verify compress succeeds
+        let data = buildMinimalJPEG()
+        let compressed = try jpeg.compress(data)
+        // Standard tables -> version 0x02
+        XCTAssertEqual(compressed[0], 0x02)
+        // Scan data is present after header
+        XCTAssertGreaterThan(compressed.count, 5)
+    }
+
+    // MARK: - B) decompress() tests
+
+    func testDecompressTooShortThrows() {
+        let data = Data([0x02, 0x00, 0x08, 0x00]) // only 4 bytes
+        XCTAssertThrowsError(try jpeg.decompress(data)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("too short"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressVersion02ReconstructsJPEG() throws {
+        let input = buildMinimalJPEG(width: 16, height: 32)
+        let compressed = try jpeg.compress(input)
+        XCTAssertEqual(compressed[0], 0x02)
+
+        let output = try jpeg.decompress(compressed)
+        XCTAssertEqual(output[0], 0xFF)
+        XCTAssertEqual(output[1], 0xD8)
+        XCTAssertTrue(output.range(of: "JFIF".data(using: .utf8)!) != nil)
+    }
+
+    func testDecompressVersion03ManualPayload() throws {
+        let width: UInt16 = 40
+        let height: UInt16 = 30
+        let scanData = Data([0xAA, 0xBB, 0xFF, 0xD9])
+
+        // Build tables data by compressing a custom JPEG and extracting tables
+        let customJPEG = buildCustomQuantJPEG(width: width, height: height)
+        guard let tablesData = try jpeg.getTablesData(customJPEG) else {
+            return XCTFail("Expected non-nil tables data for custom JPEG")
+        }
+
+        var v03 = Data()
+        v03.append(0x03)
+        v03.append(UInt8(width >> 8))
+        v03.append(UInt8(width & 0xFF))
+        v03.append(UInt8(height >> 8))
+        v03.append(UInt8(height & 0xFF))
+        // tables length (2 bytes big-endian)
+        v03.append(UInt8(tablesData.count >> 8))
+        v03.append(UInt8(tablesData.count & 0xFF))
+        v03.append(tablesData)
+        v03.append(scanData)
+
+        let output = try jpeg.decompress(v03)
+        XCTAssertEqual(output[0], 0xFF)
+        XCTAssertEqual(output[1], 0xD8)
+        XCTAssertTrue(output.range(of: "JFIF".data(using: .utf8)!) != nil)
+    }
+
+    func testDecompressVersion04WithObjectStore() throws {
+        let store = makeObjectStore(at: tempDir)
+        jpeg.setObjectStore(store)
+
+        let customJPEG = buildCustomQuantJPEG(width: 50, height: 60)
+        let compressed = try jpeg.compress(customJPEG)
+        XCTAssertEqual(compressed[0], 0x04)
+
+        // Store tables in object store at the tablesHash that compress() embedded
+        guard let tablesData = try jpeg.getTablesData(customJPEG) else {
+            return XCTFail("Expected non-nil tables data")
+        }
+        let tablesHash = Hash.compute(tablesData)
+        var headerObj = Data()
+        headerObj.append("header\n".data(using: .utf8)!)
+        headerObj.append("jpeg-tables\n".data(using: .utf8)!)
+        headerObj.append(tablesData)
+        // Write header object at the tablesHash path (matching what compress embeds)
+        try storeObjectAtHash(store: store, hash: tablesHash, data: headerObj)
+
+        let output = try jpeg.decompress(compressed)
+        XCTAssertEqual(output[0], 0xFF)
+        XCTAssertEqual(output[1], 0xD8)
+    }
+
+    func testDecompressUnknownVersion05Throws() {
+        let data = Data([0x05, 0x00, 0x08, 0x00, 0x08])
+        XCTAssertThrowsError(try jpeg.decompress(data)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Unknown"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressVersion00Throws() {
+        let data = Data([0x00, 0x00, 0x08, 0x00, 0x08])
+        XCTAssertThrowsError(try jpeg.decompress(data)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Unknown"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressVersion01Throws() {
+        let data = Data([0x01, 0x00, 0x08, 0x00, 0x08])
+        XCTAssertThrowsError(try jpeg.decompress(data)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Unknown"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressV03TruncatedLengthThrows() {
+        // Version 0x03, dims, but no tables length bytes
+        let data = Data([0x03, 0x00, 0x08, 0x00, 0x08])
+        XCTAssertThrowsError(try jpeg.decompress(data)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Missing tables length"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressV03TruncatedDataThrows() {
+        // Version 0x03, dims, length says 100 but only 2 bytes of data
+        var data = Data([0x03, 0x00, 0x08, 0x00, 0x08])
+        data.append(contentsOf: [0x00, 0x64]) // length = 100
+        data.append(contentsOf: [0xAA, 0xBB]) // only 2 bytes
+        XCTAssertThrowsError(try jpeg.decompress(data)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Truncated tables"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressV04NoObjectStoreThrows() throws {
+        // Don't set objectStore, try to decompress v04
+        let customJPEG = buildCustomQuantJPEG()
+        let compressed = try jpeg.compress(customJPEG)
+        XCTAssertEqual(compressed[0], 0x04)
+
+        // Create a fresh instance without objectStore
+        let fresh = JPEGHeaderCompression()
+        XCTAssertThrowsError(try fresh.decompress(compressed)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Object store not available"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressV04MissingHashThrows() {
+        // Version 0x04, dims, but no 32-byte hash
+        let data = Data([0x04, 0x00, 0x08, 0x00, 0x08, 0xAA])
+        XCTAssertThrowsError(try jpeg.decompress(data)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Missing tables hash"), "Message was: \(msg)")
+        }
+    }
+
+    func testDecompressEOIPresentNoDuplicate() throws {
+        // Scan data ends with FFD9 -- output should not have double EOI
+        let scanWithEOI = Data([0xAA, 0xBB, 0xFF, 0xD9])
+        let input = buildMinimalJPEG(scanData: scanWithEOI)
+        let compressed = try jpeg.compress(input)
+        let output = try jpeg.decompress(compressed)
+
+        // Count occurrences of FFD9
+        var count = 0
+        for i in 0..<(output.count - 1) {
+            if output[i] == 0xFF && output[i + 1] == 0xD9 {
+                count += 1
+            }
+        }
+        XCTAssertEqual(count, 1, "Expected exactly one EOI marker")
+    }
+
+    func testDecompressEOIAbsentAppended() throws {
+        // Scan data does NOT end with FFD9 -- output should have FFD9 appended
+        let scanNoEOI = Data([0xAA, 0xBB, 0xCC])
+        let input = buildMinimalJPEG(scanData: scanNoEOI)
+        let compressed = try jpeg.compress(input)
+        let output = try jpeg.decompress(compressed)
+
+        XCTAssertEqual(output[output.count - 2], 0xFF)
+        XCTAssertEqual(output[output.count - 1], 0xD9)
+    }
+
+    // MARK: - C) tablesAreStandard() via compress version byte
+
+    func testStandardTablesVersion02() throws {
+        let data = buildMinimalJPEG()
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x02)
+    }
+
+    func testModifiedLumaQuantVersion04() throws {
+        var modifiedLuma = standardQ20LumaTable
+        modifiedLuma[0] = 99
+        let data = buildCustomQuantJPEG(lumaTable: modifiedLuma, chromaTable: standardQ20ChromaTable)
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04)
+    }
+
+    func testModifiedChromaQuantVersion04() throws {
+        var modifiedChroma = standardQ20ChromaTable
+        modifiedChroma[0] = 1
+        let data = buildCustomQuantJPEG(lumaTable: standardQ20LumaTable, chromaTable: modifiedChroma)
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04)
+    }
+
+    func testSingleQuantTableVersion04() throws {
+        // Build a JPEG with only one quant table (non-standard count)
+        var data = Data()
+        data.append(contentsOf: [0xFF, 0xD8]) // SOI
+
+        // Only one DQT
+        data.append(contentsOf: [0xFF, 0xDB])
+        data.append(contentsOf: [0x00, 0x43]) // length = 67
+        data.append(0x00)
+        data.append(contentsOf: standardQ20LumaTable)
+
+        // SOF
+        data.append(contentsOf: [0xFF, 0xC0])
+        data.append(contentsOf: [0x00, 0x11])
+        data.append(0x08)
+        data.append(contentsOf: [0x00, 0x08, 0x00, 0x08])
+        data.append(0x03)
+        data.append(contentsOf: [0x01, 0x22, 0x00])
+        data.append(contentsOf: [0x02, 0x11, 0x01])
+        data.append(contentsOf: [0x03, 0x11, 0x01])
+
+        // Standard Huffman tables
+        appendStandardHuffmanTablesToData(&data)
+
+        // SOS
+        appendSOSToData(&data, scanData: Data([0x00, 0xFF, 0xD9]))
+
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04, "Single quant table should be non-standard")
+    }
+
+    func testModifiedDCLumaBitsVersion04() throws {
+        var modifiedBits = standardDCLumaBits
+        modifiedBits[1] = 99
+        let data = buildJPEGWithCustomHuffman(
+            dcLumaBits: modifiedBits, dcLumaVals: standardDCLumaVals,
+            acLumaBits: standardACLumaBits, acLumaVals: standardACLumaVals,
+            dcChromaBits: standardDCChromaBits, dcChromaVals: standardDCChromaVals,
+            acChromaBits: standardACChromaBits, acChromaVals: standardACChromaVals
+        )
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04)
+    }
+
+    func testModifiedACLumaValsVersion04() throws {
+        var modifiedVals = standardACLumaVals
+        modifiedVals[0] = 0xFF
+        let data = buildJPEGWithCustomHuffman(
+            dcLumaBits: standardDCLumaBits, dcLumaVals: standardDCLumaVals,
+            acLumaBits: standardACLumaBits, acLumaVals: modifiedVals,
+            dcChromaBits: standardDCChromaBits, dcChromaVals: standardDCChromaVals,
+            acChromaBits: standardACChromaBits, acChromaVals: standardACChromaVals
+        )
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04)
+    }
+
+    func testThreeQuantTablesVersion04() throws {
+        var data = Data()
+        data.append(contentsOf: [0xFF, 0xD8])
+
+        // Three DQT tables
+        for id: UInt8 in 0...2 {
+            data.append(contentsOf: [0xFF, 0xDB])
+            data.append(contentsOf: [0x00, 0x43])
+            data.append(id)
+            data.append(contentsOf: Array(repeating: UInt8(42), count: 64))
+        }
+
+        // SOF
+        data.append(contentsOf: [0xFF, 0xC0])
+        data.append(contentsOf: [0x00, 0x11])
+        data.append(0x08)
+        data.append(contentsOf: [0x00, 0x08, 0x00, 0x08])
+        data.append(0x03)
+        data.append(contentsOf: [0x01, 0x22, 0x00])
+        data.append(contentsOf: [0x02, 0x11, 0x01])
+        data.append(contentsOf: [0x03, 0x11, 0x01])
+
+        appendStandardHuffmanTablesToData(&data)
+        appendSOSToData(&data, scanData: Data([0x00, 0xFF, 0xD9]))
+
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04, "Three quant tables should be non-standard")
+    }
+
+    func testModifiedDCChromaVersion04() throws {
+        var modifiedBits = standardDCChromaBits
+        modifiedBits[0] = 5
+        let data = buildJPEGWithCustomHuffman(
+            dcLumaBits: standardDCLumaBits, dcLumaVals: standardDCLumaVals,
+            acLumaBits: standardACLumaBits, acLumaVals: standardACLumaVals,
+            dcChromaBits: modifiedBits, dcChromaVals: standardDCChromaVals,
+            acChromaBits: standardACChromaBits, acChromaVals: standardACChromaVals
+        )
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04)
+    }
+
+    func testModifiedACChromaVersion04() throws {
+        var modifiedVals = standardACChromaVals
+        modifiedVals[0] = 0xFE
+        let data = buildJPEGWithCustomHuffman(
+            dcLumaBits: standardDCLumaBits, dcLumaVals: standardDCLumaVals,
+            acLumaBits: standardACLumaBits, acLumaVals: standardACLumaVals,
+            dcChromaBits: standardDCChromaBits, dcChromaVals: standardDCChromaVals,
+            acChromaBits: standardACChromaBits, acChromaVals: modifiedVals
+        )
+        let compressed = try jpeg.compress(data)
+        XCTAssertEqual(compressed[0], 0x04)
+    }
+
+    // MARK: - D) getTablesData() tests
+
+    func testGetTablesDataNotJPEGReturnsNil() throws {
+        let data = Data([0x00, 0x00, 0x00])
+        let result = try jpeg.getTablesData(data)
+        XCTAssertNil(result)
+    }
+
+    func testGetTablesDataStandardReturnsNil() throws {
+        let data = buildMinimalJPEG()
+        let result = try jpeg.getTablesData(data)
+        XCTAssertNil(result)
+    }
+
+    func testGetTablesDataCustomReturnsNonNil() throws {
+        let data = buildCustomQuantJPEG()
+        let result = try jpeg.getTablesData(data)
+        XCTAssertNotNil(result)
+        XCTAssertGreaterThan(result!.count, 0)
+    }
+
+    func testGetTablesDataTruncatedReturnsNil() throws {
+        // A JPEG that's truncated mid-marker (no length after marker)
+        let data = Data([0xFF, 0xD8, 0xFF, 0xDB])
+        let result = try jpeg.getTablesData(data)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - E) setObjectStore() tests
+
+    func testSetObjectStoreEnablesV04Decompress() throws {
+        let store = makeObjectStore(at: tempDir)
+        jpeg.setObjectStore(store)
+
+        let customJPEG = buildCustomQuantJPEG()
+        let compressed = try jpeg.compress(customJPEG)
+        XCTAssertEqual(compressed[0], 0x04)
+
+        // Store tables at the correct hash
+        guard let tablesData = try jpeg.getTablesData(customJPEG) else {
+            return XCTFail("Expected tables data")
+        }
+        let tablesHash = Hash.compute(tablesData)
+        var headerObj = Data()
+        headerObj.append("header\n".data(using: .utf8)!)
+        headerObj.append("jpeg-tables\n".data(using: .utf8)!)
+        headerObj.append(tablesData)
+        try storeObjectAtHash(store: store, hash: tablesHash, data: headerObj)
+
+        let output = try jpeg.decompress(compressed)
+        XCTAssertEqual(output[0], 0xFF)
+        XCTAssertEqual(output[1], 0xD8)
+    }
+
+    func testSetObjectStoreWeakReference() throws {
+        let customJPEG = buildCustomQuantJPEG()
+        let compressed = try jpeg.compress(customJPEG)
+
+        autoreleasepool {
+            let store = makeObjectStore(at: tempDir)
+            jpeg.setObjectStore(store)
+        }
+
+        // After store is deallocated, decompress v04 should fail with "Object store not available"
+        XCTAssertThrowsError(try jpeg.decompress(compressed)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                return XCTFail("Expected decompressionFailed, got \(error)")
+            }
+            XCTAssertTrue(msg.contains("Object store not available"), "Message was: \(msg)")
+        }
+    }
+
+    // MARK: - F) Full round-trip tests
+
+    func testRoundTripStandardJPEG() throws {
+        let input = buildMinimalJPEG(width: 64, height: 48)
+        let compressed = try jpeg.compress(input)
+        let output = try jpeg.decompress(compressed)
+
+        XCTAssertEqual(output[0], 0xFF)
+        XCTAssertEqual(output[1], 0xD8)
+        XCTAssertTrue(output.range(of: "JFIF".data(using: .utf8)!) != nil)
+        // Output ends with EOI
+        XCTAssertEqual(output[output.count - 2], 0xFF)
+        XCTAssertEqual(output[output.count - 1], 0xD9)
+    }
+
+    func testRoundTripCustomJPEG() throws {
+        let store = makeObjectStore(at: tempDir)
+        jpeg.setObjectStore(store)
+
+        let input = buildCustomQuantJPEG(width: 100, height: 80)
+        let compressed = try jpeg.compress(input)
+        XCTAssertEqual(compressed[0], 0x04)
+
+        // Store tables at the correct hash so decompress can find them
+        guard let tablesData = try jpeg.getTablesData(input) else {
+            return XCTFail("Expected tables data")
+        }
+        let tablesHash = Hash.compute(tablesData)
+        var headerObj = Data()
+        headerObj.append("header\n".data(using: .utf8)!)
+        headerObj.append("jpeg-tables\n".data(using: .utf8)!)
+        headerObj.append(tablesData)
+        try storeObjectAtHash(store: store, hash: tablesHash, data: headerObj)
+
+        let output = try jpeg.decompress(compressed)
+        XCTAssertEqual(output[0], 0xFF)
+        XCTAssertEqual(output[1], 0xD8)
+        XCTAssertTrue(output.range(of: "JFIF".data(using: .utf8)!) != nil)
+        XCTAssertEqual(output[output.count - 2], 0xFF)
+        XCTAssertEqual(output[output.count - 1], 0xD9)
+    }
+
+    // MARK: - Additional compress edge cases
+
+    func testCompressVersion02HeaderSize() throws {
+        let scanData = Data([0xDE, 0xAD, 0xBE, 0xEF, 0xFF, 0xD9])
+        let input = buildMinimalJPEG(scanData: scanData)
+        let compressed = try jpeg.compress(input)
+        // Version 0x02: 1 byte version + 4 bytes dims + scan data
+        XCTAssertEqual(compressed[0], 0x02)
+        XCTAssertEqual(compressed.count, 5 + scanData.count)
+    }
+
+    func testCompressVersion04HeaderSize() throws {
+        let input = buildCustomQuantJPEG()
+        let compressed = try jpeg.compress(input)
+        // Version 0x04: 1 byte version + 4 bytes dims + 32 bytes hash + scan data
+        XCTAssertEqual(compressed[0], 0x04)
+        XCTAssertGreaterThanOrEqual(compressed.count, 37)
+    }
+
+    func testCompressScanDataPreserved() throws {
+        let scanData = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0xFF, 0xD9])
+        let input = buildMinimalJPEG(scanData: scanData)
+        let compressed = try jpeg.compress(input)
+        // Scan data should be at the end, starting after the 5-byte header
+        let extractedScan = compressed[5...]
+        XCTAssertEqual(Data(extractedScan), scanData)
+    }
+
+    func testCompressWithAPPMarkerInExtra() throws {
+        // APP0 marker (0xE0) with some data in extraMarkers
+        let appData = Data(repeating: 0x42, count: 10)
+        let extraMarkers: [(UInt8, Data)] = [(0xE0, appData)]
+        let data = buildMinimalJPEG(extraMarkers: extraMarkers)
+        let compressed = try jpeg.compress(data)
+        // Should still succeed and use standard tables
+        XCTAssertEqual(compressed[0], 0x02)
+    }
+
+    func testCompressDeterministicHash() throws {
+        // Compressing the same custom JPEG twice should produce the same hash
+        let input = buildCustomQuantJPEG(width: 10, height: 20)
+        let compressed1 = try jpeg.compress(input)
+        let compressed2 = try jpeg.compress(input)
+
+        XCTAssertEqual(compressed1[0], 0x04)
+        // Hash bytes 5..<37 should be identical
+        XCTAssertEqual(compressed1[5..<37], compressed2[5..<37])
+    }
+
+    func testCompressDifferentCustomTablesDifferentHash() throws {
+        let input1 = buildCustomQuantJPEG(lumaTable: Array(repeating: 10, count: 64))
+        let input2 = buildCustomQuantJPEG(lumaTable: Array(repeating: 20, count: 64))
+        let compressed1 = try jpeg.compress(input1)
+        let compressed2 = try jpeg.compress(input2)
+
+        XCTAssertEqual(compressed1[0], 0x04)
+        XCTAssertEqual(compressed2[0], 0x04)
+        XCTAssertNotEqual(compressed1[5..<37], compressed2[5..<37])
+    }
+
+    // MARK: - Additional decompress edge cases
+
+    func testDecompressV02PreservesWidthHeight() throws {
+        let width: UInt16 = 1920
+        let height: UInt16 = 1080
+        let input = buildMinimalJPEG(width: width, height: height)
+        let compressed = try jpeg.compress(input)
+        let output = try jpeg.decompress(compressed)
+
+        // Find the SOF marker in the output to verify dimensions
+        var found = false
+        for i in 0..<(output.count - 8) {
+            if output[i] == 0xFF && output[i + 1] == 0xC0 {
+                let h = UInt16(output[i + 5]) << 8 | UInt16(output[i + 6])
+                let w = UInt16(output[i + 7]) << 8 | UInt16(output[i + 8])
+                XCTAssertEqual(w, width)
+                XCTAssertEqual(h, height)
+                found = true
+                break
+            }
+        }
+        XCTAssertTrue(found, "SOF marker not found in decompressed output")
+    }
+
+    func testDecompressV02ContainsQuantTables() throws {
+        let input = buildMinimalJPEG()
+        let compressed = try jpeg.compress(input)
+        let output = try jpeg.decompress(compressed)
+
+        // Count DQT markers (0xFF 0xDB) in output
+        var dqtCount = 0
+        for i in 0..<(output.count - 1) {
+            if output[i] == 0xFF && output[i + 1] == 0xDB {
+                dqtCount += 1
+            }
+        }
+        XCTAssertEqual(dqtCount, 2, "Expected 2 DQT markers in reconstructed JPEG")
+    }
+
+    func testDecompressV02ContainsHuffmanTables() throws {
+        let input = buildMinimalJPEG()
+        let compressed = try jpeg.compress(input)
+        let output = try jpeg.decompress(compressed)
+
+        // Count DHT markers (0xFF 0xC4) in output
+        var dhtCount = 0
+        for i in 0..<(output.count - 1) {
+            if output[i] == 0xFF && output[i + 1] == 0xC4 {
+                dhtCount += 1
+            }
+        }
+        XCTAssertEqual(dhtCount, 4, "Expected 4 DHT markers in reconstructed JPEG")
+    }
+
+    func testDecompressV03WithEmptyScanData() throws {
+        let width: UInt16 = 8
+        let height: UInt16 = 8
+
+        let customJPEG = buildCustomQuantJPEG(width: width, height: height)
+        guard let tablesData = try jpeg.getTablesData(customJPEG) else {
+            return XCTFail("Expected non-nil tables")
+        }
+
+        var v03 = Data()
+        v03.append(0x03)
+        v03.append(UInt8(width >> 8))
+        v03.append(UInt8(width & 0xFF))
+        v03.append(UInt8(height >> 8))
+        v03.append(UInt8(height & 0xFF))
+        v03.append(UInt8(tablesData.count >> 8))
+        v03.append(UInt8(tablesData.count & 0xFF))
+        v03.append(tablesData)
+        // No scan data at all
+
+        let output = try jpeg.decompress(v03)
+        // Should still produce a valid JPEG start
+        XCTAssertEqual(output[0], 0xFF)
+        XCTAssertEqual(output[1], 0xD8)
+        // EOI should be appended since there's no scan data ending with FFD9
+        XCTAssertEqual(output[output.count - 2], 0xFF)
+        XCTAssertEqual(output[output.count - 1], 0xD9)
+    }
+
+    // MARK: - Helpers for building JPEGs with custom Huffman tables
+
+    private func buildJPEGWithCustomHuffman(
+        dcLumaBits: [UInt8], dcLumaVals: [UInt8],
+        acLumaBits: [UInt8], acLumaVals: [UInt8],
+        dcChromaBits: [UInt8], dcChromaVals: [UInt8],
+        acChromaBits: [UInt8], acChromaVals: [UInt8],
+        width: UInt16 = 8, height: UInt16 = 8
+    ) -> Data {
+        var data = Data()
+        data.append(contentsOf: [0xFF, 0xD8]) // SOI
+
+        // Standard quant tables
+        data.append(contentsOf: [0xFF, 0xDB])
+        data.append(contentsOf: [0x00, 0x43])
+        data.append(0x00)
+        data.append(contentsOf: standardQ20LumaTable)
+
+        data.append(contentsOf: [0xFF, 0xDB])
+        data.append(contentsOf: [0x00, 0x43])
+        data.append(0x01)
+        data.append(contentsOf: standardQ20ChromaTable)
+
+        // SOF
+        data.append(contentsOf: [0xFF, 0xC0])
+        data.append(contentsOf: [0x00, 0x11])
+        data.append(0x08)
+        data.append(UInt8(height >> 8))
+        data.append(UInt8(height & 0xFF))
+        data.append(UInt8(width >> 8))
+        data.append(UInt8(width & 0xFF))
+        data.append(0x03)
+        data.append(contentsOf: [0x01, 0x22, 0x00])
+        data.append(contentsOf: [0x02, 0x11, 0x01])
+        data.append(contentsOf: [0x03, 0x11, 0x01])
+
+        // Custom Huffman tables
+        appendHuffmanTableToData(&data, classId: 0x00, bits: dcLumaBits, vals: dcLumaVals)
+        appendHuffmanTableToData(&data, classId: 0x10, bits: acLumaBits, vals: acLumaVals)
+        appendHuffmanTableToData(&data, classId: 0x01, bits: dcChromaBits, vals: dcChromaVals)
+        appendHuffmanTableToData(&data, classId: 0x11, bits: acChromaBits, vals: acChromaVals)
+
+        // SOS
+        appendSOSToData(&data, scanData: Data([0x00, 0xFF, 0xD9]))
+
+        return data
+    }
+
+    private func appendHuffmanTableToData(_ data: inout Data, classId: UInt8, bits: [UInt8], vals: [UInt8]) {
+        data.append(contentsOf: [0xFF, 0xC4])
+        let length = UInt16(2 + 1 + 16 + vals.count)
+        data.append(UInt8(length >> 8))
+        data.append(UInt8(length & 0xFF))
+        data.append(classId)
+        data.append(contentsOf: bits)
+        data.append(contentsOf: vals)
+    }
+
+    private func appendStandardHuffmanTablesToData(_ data: inout Data) {
+        appendHuffmanTableToData(&data, classId: 0x00, bits: standardDCLumaBits, vals: standardDCLumaVals)
+        appendHuffmanTableToData(&data, classId: 0x10, bits: standardACLumaBits, vals: standardACLumaVals)
+        appendHuffmanTableToData(&data, classId: 0x01, bits: standardDCChromaBits, vals: standardDCChromaVals)
+        appendHuffmanTableToData(&data, classId: 0x11, bits: standardACChromaBits, vals: standardACChromaVals)
+    }
+
+    private func appendSOSToData(_ data: inout Data, scanData: Data) {
+        data.append(contentsOf: [0xFF, 0xDA])
+        data.append(contentsOf: [0x00, 0x0C])
+        data.append(0x03)
+        data.append(contentsOf: [0x01, 0x00])
+        data.append(contentsOf: [0x02, 0x11])
+        data.append(contentsOf: [0x03, 0x11])
+        data.append(contentsOf: [0x00, 0x3F, 0x00])
+        data.append(scanData)
+    }
+
+    /// Stores data at a specific hash path in the ObjectStore
+    /// (bypasses content-addressed storage to place data at an arbitrary hash)
+    private func storeObjectAtHash(store: ObjectStore, hash: Hash, data: Data) throws {
+        let hex = hash.hex
+        let prefix = String(hex.prefix(2))
+        let suffix = String(hex.dropFirst(2))
+
+        let objectsPath = tempDir.appendingPathComponent(".vcs/objects")
+        let dirPath = objectsPath.appendingPathComponent(prefix)
+        try FileManager.default.createDirectory(at: dirPath, withIntermediateDirectories: true)
+        try data.write(to: dirPath.appendingPathComponent(suffix))
+    }
+}

--- a/Tests/VCSTests/LZ4CompressionTests.swift
+++ b/Tests/VCSTests/LZ4CompressionTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import VCS
+
+final class LZ4CompressionTests: TempDirectoryTestCase {
+    var lz4: LZ4Compression!
+
+    override func setUp() {
+        super.setUp()
+        lz4 = LZ4Compression()
+    }
+
+    // MARK: - Name
+
+    func testName() {
+        XCTAssertEqual(lz4.name, "lz4")
+    }
+
+    // MARK: - Compress
+
+    func testCompressProducesSmaller() throws {
+        let repetitive = Data(String(repeating: "abcdefghij", count: 1000).utf8)
+        let compressed = try lz4.compress(repetitive)
+        XCTAssertLessThan(compressed.count, repetitive.count)
+    }
+
+    func testCompressEmptyDataProducesOutput() throws {
+        // Empty Data has non-nil baseAddress on modern Swift
+        // compression_encode_buffer with 0 bytes returns small header
+        let compressed = try lz4.compress(Data())
+        XCTAssertGreaterThanOrEqual(compressed.count, 0)
+    }
+
+    // MARK: - Decompress
+
+    func testDecompressInvalidData() {
+        let garbage = Data(repeating: 0xFF, count: 100)
+        XCTAssertThrowsError(try lz4.decompress(garbage)) { error in
+            XCTAssertTrue(error is CompressionError, "Expected CompressionError, got \(error)")
+        }
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripHelloWorld() throws {
+        let data = Data("Hello, World!".utf8)
+        let result = try lz4.decompress(lz4.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    func testRoundTripSmall() throws {
+        let data = Data([0x42])
+        let result = try lz4.decompress(lz4.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    func testRoundTripBinary() throws {
+        var data = Data(count: 256)
+        for i in 0..<256 { data[i] = UInt8(i % 256) }
+        let result = try lz4.decompress(lz4.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    func testRoundTripShortText() throws {
+        let data = Data("Short text".utf8)
+        let result = try lz4.decompress(lz4.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    // MARK: - setObjectStore
+
+    func testSetObjectStoreNoOp() throws {
+        let store = makeObjectStore(at: tempDir)
+        lz4.setObjectStore(store)
+        // Verify compression still works after setObjectStore
+        let data = Data("test".utf8)
+        let result = try lz4.decompress(lz4.compress(data))
+        XCTAssertEqual(result, data)
+    }
+}

--- a/Tests/VCSTests/NoCompressionTests.swift
+++ b/Tests/VCSTests/NoCompressionTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import VCS
+
+final class NoCompressionTests: TempDirectoryTestCase {
+
+    // MARK: - name
+
+    func testNameIsNone() {
+        let sut = NoCompression()
+        XCTAssertEqual(sut.name, "none")
+    }
+
+    // MARK: - compress
+
+    func testCompressReturnsIdentityForHello() throws {
+        let sut = NoCompression()
+        let input = Data("hello".utf8)
+        let result = try sut.compress(input)
+        XCTAssertEqual(result, input)
+    }
+
+    func testCompressEmptyDataReturnsEmpty() throws {
+        let sut = NoCompression()
+        let input = Data()
+        let result = try sut.compress(input)
+        XCTAssertEqual(result, input)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testCompressLargeDataReturnsSame() throws {
+        let sut = NoCompression()
+        let input = Data(repeating: 0xAB, count: 1_000_000)
+        let result = try sut.compress(input)
+        XCTAssertEqual(result, input)
+        XCTAssertEqual(result.count, 1_000_000)
+    }
+
+    // MARK: - decompress
+
+    func testDecompressReturnsIdentityForHello() throws {
+        let sut = NoCompression()
+        let input = Data("hello".utf8)
+        let result = try sut.decompress(input)
+        XCTAssertEqual(result, input)
+    }
+
+    func testDecompressEmptyDataReturnsEmpty() throws {
+        let sut = NoCompression()
+        let input = Data()
+        let result = try sut.decompress(input)
+        XCTAssertEqual(result, input)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - round-trip
+
+    func testRoundTripDecompressCompressReturnsOriginal() throws {
+        let sut = NoCompression()
+        let original = Data("round-trip test payload 🚀".utf8)
+        let compressed = try sut.compress(original)
+        let decompressed = try sut.decompress(compressed)
+        XCTAssertEqual(decompressed, original)
+    }
+
+    // MARK: - setObjectStore
+
+    func testSetObjectStoreDoesNotCrash() throws {
+        let sut = NoCompression()
+        let store = makeObjectStore(at: tempDir)
+        sut.setObjectStore(store)
+        // Verify compression still works after setObjectStore
+        let data = Data("test".utf8)
+        let result = try sut.decompress(sut.compress(data))
+        XCTAssertEqual(result, data)
+    }
+}

--- a/Tests/VCSTests/ObjectStoreTests.swift
+++ b/Tests/VCSTests/ObjectStoreTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import VCS
+
+final class ObjectStoreTests: TempDirectoryTestCase {
+    var store: ObjectStore!
+    var registry: CompressionRegistry!
+
+    override func setUp() {
+        super.setUp()
+        registry = CompressionRegistry()
+        store = ObjectStore(repositoryPath: tempDir, compressionRegistry: registry)
+    }
+
+    // MARK: - Init
+
+    func testInitCreatesObjectsDirectory() {
+        let objectsPath = tempDir.appendingPathComponent(".vcs/objects")
+        var isDir: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: objectsPath.path, isDirectory: &isDir))
+        XCTAssertTrue(isDir.boolValue)
+    }
+
+    // MARK: - Write / Read
+
+    func testWriteAndRead() throws {
+        let data = Data("hello world".utf8)
+        let hash = try store.write(data)
+        let readData = try store.read(hash)
+        XCTAssertEqual(readData, data)
+    }
+
+    func testWriteEmptyData() throws {
+        let hash = try store.write(Data())
+        let readData = try store.read(hash)
+        XCTAssertEqual(readData, Data())
+    }
+
+    func testWriteLargeData() throws {
+        let data = Data(repeating: 0x42, count: 5_000_000)
+        let hash = try store.write(data)
+        let readData = try store.read(hash)
+        XCTAssertEqual(readData, data)
+    }
+
+    func testWriteDeterministic() throws {
+        let data = Data("deterministic".utf8)
+        let hash1 = try store.write(data)
+        let hash2 = try store.write(data)
+        XCTAssertEqual(hash1, hash2)
+    }
+
+    func testWriteIdempotent() throws {
+        let data = Data("idempotent".utf8)
+        let hash1 = try store.write(data)
+        // Writing same data again should not error
+        let hash2 = try store.write(data)
+        XCTAssertEqual(hash1, hash2)
+    }
+
+    // MARK: - Read nonexistent
+
+    func testReadNonexistent() {
+        let randomHash = Hash(Data(repeating: 0xAB, count: 32))
+        XCTAssertThrowsError(try store.read(randomHash))
+    }
+
+    // MARK: - Exists
+
+    func testExistsWrittenHash() throws {
+        let data = Data("exists".utf8)
+        let hash = try store.write(data)
+        XCTAssertTrue(store.exists(hash))
+    }
+
+    func testExistsNonexistent() {
+        let randomHash = Hash(Data(repeating: 0xCD, count: 32))
+        XCTAssertFalse(store.exists(randomHash))
+    }
+
+    // MARK: - Object path sharding
+
+    func testObjectPathSharding() throws {
+        let data = Data("shard test".utf8)
+        let hash = try store.write(data)
+        let hex = hash.hex
+        let prefix = String(hex.prefix(2))
+        let suffix = String(hex.dropFirst(2))
+
+        let expectedPath = tempDir.appendingPathComponent(".vcs/objects")
+            .appendingPathComponent(prefix)
+            .appendingPathComponent(suffix)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedPath.path))
+    }
+
+    // MARK: - writeBlob / readBlob
+
+    func testWriteBlobAndReadBlob() throws {
+        let content = Data("file content".utf8)
+        let hash = try store.writeBlob(content: content, path: "file.txt")
+        let blob = try store.readBlob(hash)
+        XCTAssertEqual(blob.content, content)
+    }
+
+    func testWriteBlobJPEGCustomTables() throws {
+        let jpegData = buildCustomQuantJPEG()
+        // writeBlob stores the header object at Hash.compute(headerObj), but
+        // compress embeds Hash.compute(tablesData). These differ, so readBlob
+        // will fail when decompress tries to load tables by hash.
+        // This documents a known bug: ObjectStore.writeBlob stores the tables header
+        // at the content hash of the header object, not at the tables data hash.
+        let hash = try store.writeBlob(content: jpegData, path: "photo.jpg")
+
+        // Manually store the tables at the correct hash to enable readBlob
+        let jpegStrategy = registry.getStrategy(byName: "jpeg-header-strip") as! JPEGHeaderCompression
+        if let tablesData = try jpegStrategy.getTablesData(jpegData) {
+            let tablesHash = Hash.compute(tablesData)
+            var headerObj = Data()
+            headerObj.append("header\n".data(using: .utf8)!)
+            headerObj.append("jpeg-tables\n".data(using: .utf8)!)
+            headerObj.append(tablesData)
+            // Write at the correct hash path
+            let hex = tablesHash.hex
+            let prefix = String(hex.prefix(2))
+            let suffix = String(hex.dropFirst(2))
+            let objectsPath = tempDir.appendingPathComponent(".vcs/objects")
+            let dirPath = objectsPath.appendingPathComponent(prefix)
+            try FileManager.default.createDirectory(at: dirPath, withIntermediateDirectories: true)
+            try headerObj.write(to: dirPath.appendingPathComponent(suffix))
+        }
+
+        jpegStrategy.setObjectStore(store)
+        let blob = try store.readBlob(hash)
+        XCTAssertEqual(blob.compressionStrategy, "jpeg-header-strip")
+    }
+
+    func testWriteBlobJPEGStandardTables() throws {
+        let jpegData = buildMinimalJPEG()
+        let hash = try store.writeBlob(content: jpegData, path: "photo.jpg")
+        let blob = try store.readBlob(hash)
+        XCTAssertEqual(blob.compressionStrategy, "jpeg-header-strip")
+    }
+
+    // MARK: - writeTree / readTree
+
+    func testWriteTreeAndReadTree() throws {
+        let tree = Tree(entries: [
+            TreeEntry(name: "file.txt", hash: "abc123", isDirectory: false),
+            TreeEntry(name: "dir", hash: "def456", isDirectory: true)
+        ])
+        let hash = try store.writeTree(tree)
+        let readTree = try store.readTree(hash)
+        XCTAssertEqual(readTree.entries.count, 2)
+        XCTAssertEqual(readTree.entries[0].name, "file.txt")
+        XCTAssertEqual(readTree.entries[1].name, "dir")
+    }
+
+    // MARK: - writeCommit / readCommit
+
+    func testWriteCommitAndReadCommit() throws {
+        let commit = Commit(
+            tree: "treehash123",
+            parent: nil,
+            author: "Test Author",
+            timestamp: Date(),
+            message: "Initial commit"
+        )
+        let hash = try store.writeCommit(commit)
+        let readCommit = try store.readCommit(hash)
+        XCTAssertEqual(readCommit.tree, "treehash123")
+        XCTAssertNil(readCommit.parent)
+        XCTAssertEqual(readCommit.author, "Test Author")
+        XCTAssertEqual(readCommit.message, "Initial commit")
+    }
+
+    // MARK: - Cross-type read errors
+
+    func testReadBlobOnTreeData() throws {
+        let tree = Tree(entries: [])
+        let hash = try store.writeTree(tree)
+        XCTAssertThrowsError(try store.readBlob(hash))
+    }
+
+    func testReadTreeOnBlobData() throws {
+        let hash = try store.writeBlob(content: Data("hello".utf8), path: "file.txt")
+        XCTAssertThrowsError(try store.readTree(hash))
+    }
+
+    func testReadCommitOnBlobData() throws {
+        let hash = try store.writeBlob(content: Data("hello".utf8), path: "file.txt")
+        XCTAssertThrowsError(try store.readCommit(hash))
+    }
+}

--- a/Tests/VCSTests/ObjectTypeTests.swift
+++ b/Tests/VCSTests/ObjectTypeTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import VCS
+
+final class ObjectTypeTests: XCTestCase {
+
+    // MARK: - Case Existence
+
+    func testAllCasesExist() {
+        // Verify the three expected cases can be constructed.
+        let cases: [ObjectType] = [.blob, .tree, .commit]
+        XCTAssertEqual(cases.count, 3)
+    }
+
+    func testCasesAreDistinct() {
+        XCTAssertNotEqual(ObjectType.blob, ObjectType.tree)
+        XCTAssertNotEqual(ObjectType.blob, ObjectType.commit)
+        XCTAssertNotEqual(ObjectType.tree, ObjectType.commit)
+    }
+
+    // MARK: - Raw Values
+
+    func testBlobRawValue() {
+        XCTAssertEqual(ObjectType.blob.rawValue, "blob")
+    }
+
+    func testTreeRawValue() {
+        XCTAssertEqual(ObjectType.tree.rawValue, "tree")
+    }
+
+    func testCommitRawValue() {
+        XCTAssertEqual(ObjectType.commit.rawValue, "commit")
+    }
+
+    // MARK: - Init From Raw Value
+
+    func testInitFromRawValueBlob() {
+        let type = ObjectType(rawValue: "blob")
+        XCTAssertEqual(type, .blob)
+    }
+
+    func testInitFromRawValueTree() {
+        let type = ObjectType(rawValue: "tree")
+        XCTAssertEqual(type, .tree)
+    }
+
+    func testInitFromRawValueCommit() {
+        let type = ObjectType(rawValue: "commit")
+        XCTAssertEqual(type, .commit)
+    }
+
+    func testInitFromInvalidRawValueTag() {
+        XCTAssertNil(ObjectType(rawValue: "tag"))
+    }
+
+    func testInitFromEmptyRawValue() {
+        XCTAssertNil(ObjectType(rawValue: ""))
+    }
+
+    // MARK: - Codable: Encode
+
+    func testEncodeEachCase() throws {
+        let encoder = JSONEncoder()
+        for (objectType, expected) in [
+            (ObjectType.blob, "blob"),
+            (ObjectType.tree, "tree"),
+            (ObjectType.commit, "commit"),
+        ] {
+            let data = try encoder.encode(objectType)
+            let jsonString = String(data: data, encoding: .utf8)
+            XCTAssertEqual(jsonString, "\"\(expected)\"")
+        }
+    }
+
+    // MARK: - Codable: Decode
+
+    func testDecodeValidCases() throws {
+        let decoder = JSONDecoder()
+        for (json, expected) in [
+            ("\"blob\"", ObjectType.blob),
+            ("\"tree\"", ObjectType.tree),
+            ("\"commit\"", ObjectType.commit),
+        ] {
+            let data = Data(json.utf8)
+            let decoded = try decoder.decode(ObjectType.self, from: data)
+            XCTAssertEqual(decoded, expected)
+        }
+    }
+
+    func testDecodeInvalidValueThrows() {
+        let data = Data("\"tag\"".utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(ObjectType.self, from: data))
+    }
+
+    // MARK: - Codable: Round-Trip
+
+    func testRoundTripAllCases() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for original in [ObjectType.blob, .tree, .commit] {
+            let data = try encoder.encode(original)
+            let restored = try decoder.decode(ObjectType.self, from: data)
+            XCTAssertEqual(original, restored)
+        }
+    }
+}

--- a/Tests/VCSTests/RepositoryTests.swift
+++ b/Tests/VCSTests/RepositoryTests.swift
@@ -1,0 +1,465 @@
+import XCTest
+@testable import VCS
+
+final class RepositoryTests: TempDirectoryTestCase {
+
+    // MARK: - A) Initialization
+
+    func testInitializeCreatesVcsDirectoryStructure() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        let fm = FileManager.default
+
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent(".vcs").path))
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent(".vcs/objects").path))
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent(".vcs/refs/heads").path))
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent(".vcs/HEAD").path))
+        _ = repo
+    }
+
+    func testInitializeHeadContentIsRefToMain() throws {
+        _ = try Repository.initialize(at: tempDir)
+        let headContent = try String(contentsOf: tempDir.appendingPathComponent(".vcs/HEAD"), encoding: .utf8)
+        XCTAssertEqual(headContent, "ref: refs/heads/main\n")
+    }
+
+    func testOpeningExistingRepoSucceeds() throws {
+        _ = try Repository.initialize(at: tempDir)
+        let repo = try Repository(path: tempDir)
+        XCTAssertNotNil(repo)
+    }
+
+    func testRegistryAccessorReturnsCompressionRegistry() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        let registry = repo.registry
+        XCTAssertNotNil(registry)
+        XCTAssertNotNil(registry.getStrategy(byName: "zlib"))
+    }
+
+    // MARK: - B) Commit Operations
+
+    func testCommitEmptyWorkingDirReturnsHash() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        let hash = try repo.commit(message: "empty commit", author: "Test User")
+        XCTAssertFalse(hash.hex.isEmpty)
+        XCTAssertEqual(hash.hex.count, 64) // SHA-256 hex string
+    }
+
+    func testCommitWithFilesReturnsHash() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "hello world".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+        let hash = try repo.commit(message: "add file", author: "Test User")
+        XCTAssertFalse(hash.hex.isEmpty)
+        XCTAssertEqual(hash.hex.count, 64)
+    }
+
+    func testCommitWithSubdirectories() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        let subdir = tempDir.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+        try "nested content".write(to: subdir.appendingPathComponent("nested.txt"), atomically: true, encoding: .utf8)
+
+        let hash = try repo.commit(message: "add nested", author: "Test User")
+        XCTAssertFalse(hash.hex.isEmpty)
+    }
+
+    func testMultipleCommitsSecondHasParentPointingToFirst() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "v1".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        let firstHash = try repo.commit(message: "first", author: "Test User")
+
+        try "v2".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "second", author: "Test User")
+
+        let commits = try repo.log(limit: 2)
+        XCTAssertEqual(commits.count, 2)
+        XCTAssertEqual(commits[0].parent, firstHash.hex)
+    }
+
+    func testCommitMessagePreserved() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "data".write(to: tempDir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "my special message", author: "Author")
+
+        let commits = try repo.log(limit: 1)
+        XCTAssertEqual(commits.first?.message, "my special message")
+    }
+
+    func testCommitAuthorPreserved() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "data".write(to: tempDir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "msg", author: "Jane Doe <jane@example.com>")
+
+        let commits = try repo.log(limit: 1)
+        XCTAssertEqual(commits.first?.author, "Jane Doe <jane@example.com>")
+    }
+
+    func testGetCurrentCommitNilBeforeFirstCommitNonNilAfter() throws {
+        let repo = try Repository.initialize(at: tempDir)
+
+        // Before any commit, log should return empty (getCurrentCommit is nil internally)
+        let logBefore = try repo.log()
+        XCTAssertTrue(logBefore.isEmpty)
+
+        // After a commit, log returns results (getCurrentCommit is non-nil)
+        try "content".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "first commit", author: "Author")
+        let logAfter = try repo.log()
+        XCTAssertEqual(logAfter.count, 1)
+    }
+
+    // MARK: - C) Log Operations
+
+    func testLogNoCommitsReturnsEmptyArray() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        let commits = try repo.log()
+        XCTAssertTrue(commits.isEmpty)
+    }
+
+    func testLogOneCommitReturnsSingleElement() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "x".write(to: tempDir.appendingPathComponent("x.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "one", author: "A")
+
+        let commits = try repo.log()
+        XCTAssertEqual(commits.count, 1)
+    }
+
+    func testLogMultipleCommitsNewestFirst() throws {
+        let repo = try Repository.initialize(at: tempDir)
+
+        for i in 1...3 {
+            try "v\(i)".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+            _ = try repo.commit(message: "commit \(i)", author: "A")
+        }
+
+        let commits = try repo.log()
+        XCTAssertEqual(commits.count, 3)
+        XCTAssertEqual(commits[0].message, "commit 3")
+        XCTAssertEqual(commits[1].message, "commit 2")
+        XCTAssertEqual(commits[2].message, "commit 1")
+    }
+
+    func testLogDefaultLimitReturnsTen() throws {
+        let repo = try Repository.initialize(at: tempDir)
+
+        for i in 1...15 {
+            try "v\(i)".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+            _ = try repo.commit(message: "commit \(i)", author: "A")
+        }
+
+        let commits = try repo.log()
+        XCTAssertEqual(commits.count, 10)
+    }
+
+    func testLogCustomLimit() throws {
+        let repo = try Repository.initialize(at: tempDir)
+
+        for i in 1...15 {
+            try "v\(i)".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+            _ = try repo.commit(message: "commit \(i)", author: "A")
+        }
+
+        let commits = try repo.log(limit: 5)
+        XCTAssertEqual(commits.count, 5)
+    }
+
+    func testLogLimitLargerThanHistory() throws {
+        let repo = try Repository.initialize(at: tempDir)
+
+        for i in 1...3 {
+            try "v\(i)".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+            _ = try repo.commit(message: "commit \(i)", author: "A")
+        }
+
+        let commits = try repo.log(limit: 100)
+        XCTAssertEqual(commits.count, 3)
+    }
+
+    func testLogLimitZeroReturnsEmptyArray() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "data".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "exists", author: "A")
+
+        let commits = try repo.log(limit: 0)
+        XCTAssertEqual(commits.count, 0)
+    }
+
+    // MARK: - D) Checkout Operations
+
+    func testCheckoutValidCommitRestoresFiles() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        let filePath = tempDir.appendingPathComponent("hello.txt")
+
+        try "version 1".write(to: filePath, atomically: true, encoding: .utf8)
+        let firstHash = try repo.commit(message: "v1", author: "A")
+
+        try "version 2".write(to: filePath, atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "v2", author: "A")
+
+        try repo.checkout(firstHash)
+
+        let content = try String(contentsOf: filePath, encoding: .utf8)
+        XCTAssertEqual(content, "version 1")
+    }
+
+    func testCheckoutUpdatesHEAD() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "data".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        let commitHash = try repo.commit(message: "initial", author: "A")
+
+        // Write a direct hash to HEAD so updateHead writes to HEAD directly
+        let headPath = tempDir.appendingPathComponent(".vcs/HEAD")
+        try commitHash.hex.write(to: headPath, atomically: true, encoding: .utf8)
+
+        try repo.checkout(commitHash)
+
+        let headContent = try String(contentsOf: headPath, encoding: .utf8)
+        XCTAssertEqual(headContent, commitHash.hex)
+    }
+
+    func testCheckoutWithNestedDirectories() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        let nested = tempDir.appendingPathComponent("a/b")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "deep content".write(to: nested.appendingPathComponent("deep.txt"), atomically: true, encoding: .utf8)
+        try "root content".write(to: tempDir.appendingPathComponent("root.txt"), atomically: true, encoding: .utf8)
+
+        let commitHash = try repo.commit(message: "nested structure", author: "A")
+
+        // Remove the files to simulate a different state
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("a"))
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("root.txt"))
+
+        try repo.checkout(commitHash)
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: nested.appendingPathComponent("deep.txt").path))
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("root.txt").path))
+
+        let deepContent = try String(contentsOf: nested.appendingPathComponent("deep.txt"), encoding: .utf8)
+        XCTAssertEqual(deepContent, "deep content")
+    }
+
+    func testCheckoutEmptyTreeNoFilesBesidesVcs() throws {
+        let repo = try Repository.initialize(at: tempDir)
+
+        // Commit with no files (empty working dir besides .vcs)
+        let emptyHash = try repo.commit(message: "empty", author: "A")
+
+        // Add a file then commit
+        try "temp".write(to: tempDir.appendingPathComponent("temp.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "with file", author: "A")
+
+        // Checkout the empty commit - it restores the empty tree
+        try repo.checkout(emptyHash)
+
+        // The checkout reconstructs from tree; temp.txt from previous state may still exist
+        // since checkout only writes files from the tree but does not delete extras.
+        // The key assertion is that .vcs still exists and checkout did not throw.
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent(".vcs").path))
+    }
+
+    // MARK: - E) Ignore Patterns
+
+    func testDefaultIgnoreVcsAlwaysIgnoredWithoutVcsignore() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "data".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try repo.commit(message: "commit", author: "A")
+
+        // .vcs directory should not appear in committed tree.
+        // Verify by checking out and seeing that no .vcs files are
+        // overwritten or duplicated. The commit succeeding without
+        // infinite recursion into .vcs/objects proves .vcs is ignored.
+        let commits = try repo.log()
+        XCTAssertEqual(commits.count, 1)
+    }
+
+    func testVcsignoreWithPatternsExcludesMatchingFiles() throws {
+        _ = try Repository.initialize(at: tempDir)
+        try "build\n".write(to: tempDir.appendingPathComponent(".vcsignore"), atomically: true, encoding: .utf8)
+
+        // Re-open repo so it reads the .vcsignore
+        let repo = try Repository(path: tempDir)
+
+        try FileManager.default.createDirectory(at: tempDir.appendingPathComponent("build"), withIntermediateDirectories: true)
+        try "artifact".write(to: tempDir.appendingPathComponent("build/output.o"), atomically: true, encoding: .utf8)
+        try "source".write(to: tempDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+
+        let commitHash = try repo.commit(message: "with ignore", author: "A")
+
+        // Remove files, checkout, and verify build dir is NOT restored
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("build"))
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("main.swift"))
+
+        try repo.checkout(commitHash)
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("main.swift").path))
+        XCTAssertFalse(fm.fileExists(atPath: tempDir.appendingPathComponent("build/output.o").path))
+    }
+
+    func testVcsignoreCommentsSkipped() throws {
+        _ = try Repository.initialize(at: tempDir)
+        try "# this is a comment\nbuild\n".write(to: tempDir.appendingPathComponent(".vcsignore"), atomically: true, encoding: .utf8)
+
+        let repo = try Repository(path: tempDir)
+
+        try FileManager.default.createDirectory(at: tempDir.appendingPathComponent("build"), withIntermediateDirectories: true)
+        try "artifact".write(to: tempDir.appendingPathComponent("build/out.o"), atomically: true, encoding: .utf8)
+        try "code".write(to: tempDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+
+        let commitHash = try repo.commit(message: "ignore comments", author: "A")
+
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("build"))
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("main.swift"))
+
+        try repo.checkout(commitHash)
+
+        // "# this is a comment" should not be treated as a pattern
+        // "build" should be ignored, main.swift should be present
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("main.swift").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("build/out.o").path))
+    }
+
+    func testVcsignoreEmptyLinesSkipped() throws {
+        _ = try Repository.initialize(at: tempDir)
+        try "\n\nbuild\n\n".write(to: tempDir.appendingPathComponent(".vcsignore"), atomically: true, encoding: .utf8)
+
+        let repo = try Repository(path: tempDir)
+
+        try FileManager.default.createDirectory(at: tempDir.appendingPathComponent("build"), withIntermediateDirectories: true)
+        try "artifact".write(to: tempDir.appendingPathComponent("build/out.o"), atomically: true, encoding: .utf8)
+        try "code".write(to: tempDir.appendingPathComponent("src.swift"), atomically: true, encoding: .utf8)
+
+        let commitHash = try repo.commit(message: "empty lines", author: "A")
+
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("build"))
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("src.swift"))
+
+        try repo.checkout(commitHash)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("src.swift").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("build/out.o").path))
+    }
+
+    func testVcsAlwaysIgnoredEvenIfNotInVcsignore() throws {
+        _ = try Repository.initialize(at: tempDir)
+        // .vcsignore that does NOT mention .vcs
+        try "build\n".write(to: tempDir.appendingPathComponent(".vcsignore"), atomically: true, encoding: .utf8)
+
+        let repo = try Repository(path: tempDir)
+        try "source".write(to: tempDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+
+        // If .vcs were not auto-ignored, committing would recurse into .vcs/objects and potentially fail
+        // or produce a different tree. The fact that this succeeds confirms .vcs is always ignored.
+        let hash = try repo.commit(message: "vcs auto-ignored", author: "A")
+        XCTAssertFalse(hash.hex.isEmpty)
+    }
+
+    func testShouldIgnoreSubstringMatchBuildMatchesBuildOutput() throws {
+        _ = try Repository.initialize(at: tempDir)
+        try "build\n".write(to: tempDir.appendingPathComponent(".vcsignore"), atomically: true, encoding: .utf8)
+
+        let repo = try Repository(path: tempDir)
+
+        // "build" pattern should match "build/output" via substring contains
+        let buildDir = tempDir.appendingPathComponent("build")
+        try FileManager.default.createDirectory(at: buildDir.appendingPathComponent("output"), withIntermediateDirectories: true)
+        try "binary".write(to: buildDir.appendingPathComponent("output/app"), atomically: true, encoding: .utf8)
+        try "src".write(to: tempDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+
+        let commitHash = try repo.commit(message: "substring match", author: "A")
+
+        try FileManager.default.removeItem(at: buildDir)
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("main.swift"))
+
+        try repo.checkout(commitHash)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("main.swift").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: buildDir.appendingPathComponent("output/app").path))
+    }
+
+    func testShouldIgnoreNoMatchBuildDoesNotMatchSourceMainSwift() throws {
+        _ = try Repository.initialize(at: tempDir)
+        try "build\n".write(to: tempDir.appendingPathComponent(".vcsignore"), atomically: true, encoding: .utf8)
+
+        let repo = try Repository(path: tempDir)
+
+        let sourceDir = tempDir.appendingPathComponent("source")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try "code".write(to: sourceDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+
+        let commitHash = try repo.commit(message: "no match", author: "A")
+
+        try FileManager.default.removeItem(at: sourceDir)
+
+        try repo.checkout(commitHash)
+
+        // "source/main.swift" does not contain "build", so it should be committed and restored
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sourceDir.appendingPathComponent("main.swift").path))
+    }
+
+    func testMultipleIgnorePatternsAllApplied() throws {
+        _ = try Repository.initialize(at: tempDir)
+        try "build\ntemp\n.cache\n".write(to: tempDir.appendingPathComponent(".vcsignore"), atomically: true, encoding: .utf8)
+
+        let repo = try Repository(path: tempDir)
+
+        try FileManager.default.createDirectory(at: tempDir.appendingPathComponent("build"), withIntermediateDirectories: true)
+        try "b".write(to: tempDir.appendingPathComponent("build/out"), atomically: true, encoding: .utf8)
+
+        try FileManager.default.createDirectory(at: tempDir.appendingPathComponent("temp"), withIntermediateDirectories: true)
+        try "t".write(to: tempDir.appendingPathComponent("temp/scratch"), atomically: true, encoding: .utf8)
+
+        try FileManager.default.createDirectory(at: tempDir.appendingPathComponent(".cache"), withIntermediateDirectories: true)
+        try "c".write(to: tempDir.appendingPathComponent(".cache/data"), atomically: true, encoding: .utf8)
+
+        try "keep".write(to: tempDir.appendingPathComponent("keep.txt"), atomically: true, encoding: .utf8)
+
+        let commitHash = try repo.commit(message: "multi ignore", author: "A")
+
+        // Clean up everything
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("build"))
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("temp"))
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent(".cache"))
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("keep.txt"))
+
+        try repo.checkout(commitHash)
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: tempDir.appendingPathComponent("keep.txt").path))
+        XCTAssertFalse(fm.fileExists(atPath: tempDir.appendingPathComponent("build/out").path))
+        XCTAssertFalse(fm.fileExists(atPath: tempDir.appendingPathComponent("temp/scratch").path))
+        XCTAssertFalse(fm.fileExists(atPath: tempDir.appendingPathComponent(".cache/data").path))
+    }
+
+    // MARK: - F) HEAD Management
+
+    func testUpdateHeadWithRefWritesHashToRefFile() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "data".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        let commitHash = try repo.commit(message: "initial", author: "A")
+
+        // HEAD is "ref: refs/heads/main", so the hash should be in refs/heads/main
+        let refPath = tempDir.appendingPathComponent(".vcs/refs/heads/main")
+        let refContent = try String(contentsOf: refPath, encoding: .utf8)
+        XCTAssertEqual(refContent, commitHash.hex)
+    }
+
+    func testGetCurrentCommitAfterDirectHashInHEAD() throws {
+        let repo = try Repository.initialize(at: tempDir)
+        try "data".write(to: tempDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        let commitHash = try repo.commit(message: "initial", author: "A")
+
+        // Overwrite HEAD with a direct hash (detached HEAD state)
+        let headPath = tempDir.appendingPathComponent(".vcs/HEAD")
+        try commitHash.hex.write(to: headPath, atomically: true, encoding: .utf8)
+
+        // Now log should still work by reading the hash directly from HEAD
+        let commits = try repo.log()
+        XCTAssertEqual(commits.count, 1)
+        XCTAssertEqual(commits.first?.message, "initial")
+    }
+}

--- a/Tests/VCSTests/TestHelpers.swift
+++ b/Tests/VCSTests/TestHelpers.swift
@@ -1,0 +1,272 @@
+import XCTest
+@testable import VCS
+
+// MARK: - TempDirectoryTestCase
+
+class TempDirectoryTestCase: XCTestCase {
+    var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+}
+
+// MARK: - ObjectStore Factory
+
+func makeObjectStore(at path: URL) -> ObjectStore {
+    let registry = CompressionRegistry()
+    return ObjectStore(repositoryPath: path, compressionRegistry: registry)
+}
+
+// MARK: - Minimal JPEG Builder
+
+/// Builds a synthetic JPEG byte sequence with configurable tables, dimensions, and markers.
+/// This is critical for JPEGHeaderCompression tests.
+func buildMinimalJPEG(
+    width: UInt16 = 8,
+    height: UInt16 = 8,
+    useStandardQuantTables: Bool = true,
+    useStandardHuffmanTables: Bool = true,
+    includeSOF: Bool = true,
+    sofMarker: UInt8 = 0xC0,
+    includeSOS: Bool = true,
+    scanData: Data? = nil,
+    extraMarkers: [(UInt8, Data)] = []
+) -> Data {
+    var jpeg = Data()
+
+    // SOI
+    jpeg.append(contentsOf: [0xFF, 0xD8])
+
+    // Extra markers (APP, RST, TEM, etc.)
+    for (marker, markerData) in extraMarkers {
+        jpeg.append(0xFF)
+        jpeg.append(marker)
+        if marker != 0x01 && !(marker >= 0xD0 && marker <= 0xD7) {
+            // Markers with length fields
+            let length = UInt16(markerData.count + 2)
+            jpeg.append(UInt8(length >> 8))
+            jpeg.append(UInt8(length & 0xFF))
+            jpeg.append(markerData)
+        }
+        // TEM (0x01) and RST (0xD0-0xD7) have no length field or data
+    }
+
+    // DQT markers
+    if useStandardQuantTables {
+        // Luma table (id=0)
+        jpeg.append(contentsOf: [0xFF, 0xDB])
+        jpeg.append(contentsOf: [0x00, 0x43]) // length = 67
+        jpeg.append(0x00) // table id
+        jpeg.append(contentsOf: standardQ20LumaTable)
+
+        // Chroma table (id=1)
+        jpeg.append(contentsOf: [0xFF, 0xDB])
+        jpeg.append(contentsOf: [0x00, 0x43]) // length = 67
+        jpeg.append(0x01) // table id
+        jpeg.append(contentsOf: standardQ20ChromaTable)
+    }
+
+    // SOF marker
+    if includeSOF {
+        jpeg.append(0xFF)
+        jpeg.append(sofMarker)
+        jpeg.append(contentsOf: [0x00, 0x11]) // length = 17
+        jpeg.append(0x08) // precision
+        jpeg.append(UInt8(height >> 8))
+        jpeg.append(UInt8(height & 0xFF))
+        jpeg.append(UInt8(width >> 8))
+        jpeg.append(UInt8(width & 0xFF))
+        jpeg.append(0x03) // 3 components
+        jpeg.append(contentsOf: [0x01, 0x22, 0x00]) // Y
+        jpeg.append(contentsOf: [0x02, 0x11, 0x01]) // Cb
+        jpeg.append(contentsOf: [0x03, 0x11, 0x01]) // Cr
+    }
+
+    // DHT markers
+    if useStandardHuffmanTables {
+        // DC Luma (classId=0x00)
+        appendHuffmanTable(to: &jpeg, classId: 0x00, bits: standardDCLumaBits, vals: standardDCLumaVals)
+        // AC Luma (classId=0x10)
+        appendHuffmanTable(to: &jpeg, classId: 0x10, bits: standardACLumaBits, vals: standardACLumaVals)
+        // DC Chroma (classId=0x01)
+        appendHuffmanTable(to: &jpeg, classId: 0x01, bits: standardDCChromaBits, vals: standardDCChromaVals)
+        // AC Chroma (classId=0x11)
+        appendHuffmanTable(to: &jpeg, classId: 0x11, bits: standardACChromaBits, vals: standardACChromaVals)
+    }
+
+    // SOS marker
+    if includeSOS {
+        jpeg.append(contentsOf: [0xFF, 0xDA])
+        jpeg.append(contentsOf: [0x00, 0x0C]) // length = 12
+        jpeg.append(0x03) // 3 components
+        jpeg.append(contentsOf: [0x01, 0x00]) // Y: DC=0, AC=0
+        jpeg.append(contentsOf: [0x02, 0x11]) // Cb: DC=1, AC=1
+        jpeg.append(contentsOf: [0x03, 0x11]) // Cr: DC=1, AC=1
+        jpeg.append(contentsOf: [0x00, 0x3F, 0x00]) // spectral selection
+
+        // Scan data
+        let scan = scanData ?? Data([0x00, 0xFF, 0xD9])
+        jpeg.append(scan)
+    }
+
+    return jpeg
+}
+
+private func appendHuffmanTable(to jpeg: inout Data, classId: UInt8, bits: [UInt8], vals: [UInt8]) {
+    jpeg.append(contentsOf: [0xFF, 0xC4])
+    let length = UInt16(2 + 1 + 16 + vals.count)
+    jpeg.append(UInt8(length >> 8))
+    jpeg.append(UInt8(length & 0xFF))
+    jpeg.append(classId)
+    jpeg.append(contentsOf: bits)
+    jpeg.append(contentsOf: vals)
+}
+
+// MARK: - Standard JPEG Tables (must match JPEGHeaderCompression.swift exactly)
+
+let standardQ20LumaTable: [UInt8] = [
+    16, 11, 12, 14, 12, 10, 16, 14,
+    13, 14, 18, 17, 16, 19, 24, 40,
+    26, 24, 22, 22, 24, 49, 35, 37,
+    29, 40, 58, 51, 61, 60, 57, 51,
+    56, 55, 64, 72, 92, 78, 64, 68,
+    87, 69, 55, 56, 80, 109, 81, 87,
+    95, 98, 103, 104, 103, 62, 77, 113,
+    121, 112, 100, 120, 92, 101, 103, 99
+]
+
+let standardQ20ChromaTable: [UInt8] = [
+    17, 18, 18, 24, 21, 24, 47, 26,
+    26, 47, 99, 66, 56, 66, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99
+]
+
+let standardDCLumaBits: [UInt8] = [0, 1, 5, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]
+let standardDCLumaVals: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+let standardACLumaBits: [UInt8] = [0, 2, 1, 3, 3, 2, 4, 3, 5, 5, 4, 4, 0, 0, 1, 125]
+let standardACLumaVals: [UInt8] = [
+    0x01, 0x02, 0x03, 0x00, 0x04, 0x11, 0x05, 0x12,
+    0x21, 0x31, 0x41, 0x06, 0x13, 0x51, 0x61, 0x07,
+    0x22, 0x71, 0x14, 0x32, 0x81, 0x91, 0xA1, 0x08,
+    0x23, 0x42, 0xB1, 0xC1, 0x15, 0x52, 0xD1, 0xF0,
+    0x24, 0x33, 0x62, 0x72, 0x82, 0x09, 0x0A, 0x16,
+    0x17, 0x18, 0x19, 0x1A, 0x25, 0x26, 0x27, 0x28,
+    0x29, 0x2A, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
+    0x3A, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
+    0x4A, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,
+    0x5A, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
+    0x6A, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
+    0x7A, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,
+    0x8A, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98,
+    0x99, 0x9A, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7,
+    0xA8, 0xA9, 0xAA, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6,
+    0xB7, 0xB8, 0xB9, 0xBA, 0xC2, 0xC3, 0xC4, 0xC5,
+    0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xD2, 0xD3, 0xD4,
+    0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xE1, 0xE2,
+    0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA,
+    0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8,
+    0xF9, 0xFA
+]
+
+let standardDCChromaBits: [UInt8] = [0, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
+let standardDCChromaVals: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+let standardACChromaBits: [UInt8] = [0, 2, 1, 2, 4, 4, 3, 4, 7, 5, 4, 4, 0, 1, 2, 119]
+let standardACChromaVals: [UInt8] = [
+    0x00, 0x01, 0x02, 0x03, 0x11, 0x04, 0x05, 0x21,
+    0x31, 0x06, 0x12, 0x41, 0x51, 0x07, 0x61, 0x71,
+    0x13, 0x22, 0x32, 0x81, 0x08, 0x14, 0x42, 0x91,
+    0xA1, 0xB1, 0xC1, 0x09, 0x23, 0x33, 0x52, 0xF0,
+    0x15, 0x62, 0x72, 0xD1, 0x0A, 0x16, 0x24, 0x34,
+    0xE1, 0x25, 0xF1, 0x17, 0x18, 0x19, 0x1A, 0x26,
+    0x27, 0x28, 0x29, 0x2A, 0x35, 0x36, 0x37, 0x38,
+    0x39, 0x3A, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+    0x49, 0x4A, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+    0x59, 0x5A, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+    0x69, 0x6A, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+    0x79, 0x7A, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
+    0x88, 0x89, 0x8A, 0x92, 0x93, 0x94, 0x95, 0x96,
+    0x97, 0x98, 0x99, 0x9A, 0xA2, 0xA3, 0xA4, 0xA5,
+    0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xB2, 0xB3, 0xB4,
+    0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xC2, 0xC3,
+    0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xD2,
+    0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA,
+    0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9,
+    0xEA, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8,
+    0xF9, 0xFA
+]
+
+/// Build a JPEG with custom (non-standard) quantization tables
+func buildCustomQuantJPEG(
+    width: UInt16 = 8,
+    height: UInt16 = 8,
+    lumaTable: [UInt8]? = nil,
+    chromaTable: [UInt8]? = nil
+) -> Data {
+    var jpeg = Data()
+
+    // SOI
+    jpeg.append(contentsOf: [0xFF, 0xD8])
+
+    // Custom luma quant table
+    let luma = lumaTable ?? Array(repeating: UInt8(50), count: 64)
+    jpeg.append(contentsOf: [0xFF, 0xDB])
+    jpeg.append(contentsOf: [0x00, 0x43])
+    jpeg.append(0x00)
+    jpeg.append(contentsOf: luma)
+
+    // Custom chroma quant table
+    let chroma = chromaTable ?? Array(repeating: UInt8(60), count: 64)
+    jpeg.append(contentsOf: [0xFF, 0xDB])
+    jpeg.append(contentsOf: [0x00, 0x43])
+    jpeg.append(0x01)
+    jpeg.append(contentsOf: chroma)
+
+    // SOF
+    jpeg.append(contentsOf: [0xFF, 0xC0])
+    jpeg.append(contentsOf: [0x00, 0x11])
+    jpeg.append(0x08)
+    jpeg.append(UInt8(height >> 8))
+    jpeg.append(UInt8(height & 0xFF))
+    jpeg.append(UInt8(width >> 8))
+    jpeg.append(UInt8(width & 0xFF))
+    jpeg.append(0x03)
+    jpeg.append(contentsOf: [0x01, 0x22, 0x00])
+    jpeg.append(contentsOf: [0x02, 0x11, 0x01])
+    jpeg.append(contentsOf: [0x03, 0x11, 0x01])
+
+    // Standard Huffman tables
+    appendHuffmanTable(to: &jpeg, classId: 0x00, bits: standardDCLumaBits, vals: standardDCLumaVals)
+    appendHuffmanTable(to: &jpeg, classId: 0x10, bits: standardACLumaBits, vals: standardACLumaVals)
+    appendHuffmanTable(to: &jpeg, classId: 0x01, bits: standardDCChromaBits, vals: standardDCChromaVals)
+    appendHuffmanTable(to: &jpeg, classId: 0x11, bits: standardACChromaBits, vals: standardACChromaVals)
+
+    // SOS
+    jpeg.append(contentsOf: [0xFF, 0xDA])
+    jpeg.append(contentsOf: [0x00, 0x0C])
+    jpeg.append(0x03)
+    jpeg.append(contentsOf: [0x01, 0x00])
+    jpeg.append(contentsOf: [0x02, 0x11])
+    jpeg.append(contentsOf: [0x03, 0x11])
+    jpeg.append(contentsOf: [0x00, 0x3F, 0x00])
+
+    // Scan data + EOI
+    jpeg.append(contentsOf: [0x00, 0xFF, 0xD9])
+
+    return jpeg
+}

--- a/Tests/VCSTests/TreeTests.swift
+++ b/Tests/VCSTests/TreeTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+@testable import VCS
+
+final class TreeTests: XCTestCase {
+
+    // MARK: - TreeEntry init
+
+    func testTreeEntryInitFileEntry() {
+        let entry = TreeEntry(name: "readme.txt", hash: "abc123", isDirectory: false)
+        XCTAssertEqual(entry.name, "readme.txt")
+        XCTAssertEqual(entry.hash, "abc123")
+        XCTAssertFalse(entry.isDirectory)
+    }
+
+    func testTreeEntryInitDirectoryEntry() {
+        let entry = TreeEntry(name: "src", hash: "def456", isDirectory: true)
+        XCTAssertEqual(entry.name, "src")
+        XCTAssertEqual(entry.hash, "def456")
+        XCTAssertTrue(entry.isDirectory)
+    }
+
+    func testTreeEntryInitEmptyName() {
+        let entry = TreeEntry(name: "", hash: "abc123", isDirectory: false)
+        XCTAssertEqual(entry.name, "")
+        XCTAssertEqual(entry.hash, "abc123")
+        XCTAssertFalse(entry.isDirectory)
+    }
+
+    func testTreeEntryInitEmptyHash() {
+        let entry = TreeEntry(name: "file.txt", hash: "", isDirectory: false)
+        XCTAssertEqual(entry.name, "file.txt")
+        XCTAssertEqual(entry.hash, "")
+        XCTAssertFalse(entry.isDirectory)
+    }
+
+    // MARK: - Tree init
+
+    func testTreeInitEmptyEntries() {
+        let tree = Tree(entries: [])
+        XCTAssertTrue(tree.entries.isEmpty)
+    }
+
+    func testTreeInitSingleFile() {
+        let entry = TreeEntry(name: "file.txt", hash: "aaa", isDirectory: false)
+        let tree = Tree(entries: [entry])
+        XCTAssertEqual(tree.entries.count, 1)
+        XCTAssertEqual(tree.entries[0].name, "file.txt")
+        XCTAssertFalse(tree.entries[0].isDirectory)
+    }
+
+    func testTreeInitSingleDirectory() {
+        let entry = TreeEntry(name: "lib", hash: "bbb", isDirectory: true)
+        let tree = Tree(entries: [entry])
+        XCTAssertEqual(tree.entries.count, 1)
+        XCTAssertEqual(tree.entries[0].name, "lib")
+        XCTAssertTrue(tree.entries[0].isDirectory)
+    }
+
+    func testTreeInitMixedEntries() {
+        let entries = [
+            TreeEntry(name: "file.txt", hash: "aaa", isDirectory: false),
+            TreeEntry(name: "src", hash: "bbb", isDirectory: true),
+            TreeEntry(name: "readme.md", hash: "ccc", isDirectory: false),
+        ]
+        let tree = Tree(entries: entries)
+        XCTAssertEqual(tree.entries.count, 3)
+        XCTAssertFalse(tree.entries[0].isDirectory)
+        XCTAssertTrue(tree.entries[1].isDirectory)
+        XCTAssertFalse(tree.entries[2].isDirectory)
+    }
+
+    func testTreeInitManyEntries() {
+        let entries = (0..<150).map { i in
+            TreeEntry(name: "file_\(i).txt", hash: "hash_\(i)", isDirectory: i % 2 == 0)
+        }
+        let tree = Tree(entries: entries)
+        XCTAssertEqual(tree.entries.count, 150)
+        XCTAssertEqual(tree.entries[0].name, "file_0.txt")
+        XCTAssertEqual(tree.entries[149].name, "file_149.txt")
+    }
+
+    // MARK: - encode()
+
+    func testEncodeProducesTreePrefix() throws {
+        let tree = Tree(entries: [TreeEntry(name: "a.txt", hash: "h1", isDirectory: false)])
+        let data = try tree.encode()
+        let str = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(str.hasPrefix("tree\n"))
+    }
+
+    func testEncodeProducesValidJSONAfterPrefix() throws {
+        let entry = TreeEntry(name: "a.txt", hash: "h1", isDirectory: false)
+        let tree = Tree(entries: [entry])
+        let data = try tree.encode()
+        let parts = data.split(separator: 0x0A, maxSplits: 1, omittingEmptySubsequences: false)
+        XCTAssertEqual(parts.count, 2)
+        let jsonData = Data(parts[1])
+        let decoded = try JSONDecoder().decode([TreeEntry].self, from: jsonData)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].name, "a.txt")
+    }
+
+    func testEncodeEmptyTreeProducesExpectedOutput() throws {
+        let tree = Tree(entries: [])
+        let data = try tree.encode()
+        let str = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(str, "tree\n[]")
+    }
+
+    // MARK: - decode()
+
+    func testDecodeValidEncodedData() throws {
+        let json = try JSONEncoder().encode([TreeEntry(name: "f.txt", hash: "h", isDirectory: false)])
+        var raw = "tree\n".data(using: .utf8)!
+        raw.append(json)
+        let tree = try Tree.decode(raw)
+        XCTAssertEqual(tree.entries.count, 1)
+        XCTAssertEqual(tree.entries[0].name, "f.txt")
+    }
+
+    func testDecodeEmptyEntries() throws {
+        let raw = "tree\n[]".data(using: .utf8)!
+        let tree = try Tree.decode(raw)
+        XCTAssertTrue(tree.entries.isEmpty)
+    }
+
+    func testDecodeInvalidPrefixThrows() {
+        let raw = "nottree\n[]".data(using: .utf8)!
+        XCTAssertThrowsError(try Tree.decode(raw)) { error in
+            guard case CompressionError.decompressionFailed(let msg) = error else {
+                XCTFail("Expected CompressionError.decompressionFailed, got \(error)")
+                return
+            }
+            XCTAssertEqual(msg, "Invalid tree format")
+        }
+    }
+
+    func testDecodeNoNewlineThrows() {
+        let raw = "tree[]".data(using: .utf8)!
+        XCTAssertThrowsError(try Tree.decode(raw)) { error in
+            guard case CompressionError.decompressionFailed = error else {
+                XCTFail("Expected CompressionError.decompressionFailed, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testDecodeInvalidJSONThrows() {
+        let raw = "tree\n{not valid json}".data(using: .utf8)!
+        XCTAssertThrowsError(try Tree.decode(raw))
+    }
+
+    func testDecodeEmptyDataThrows() {
+        let raw = Data()
+        XCTAssertThrowsError(try Tree.decode(raw)) { error in
+            guard case CompressionError.decompressionFailed = error else {
+                XCTFail("Expected CompressionError.decompressionFailed, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripEncodeDecode() throws {
+        let entries = [
+            TreeEntry(name: "main.swift", hash: "abc", isDirectory: false),
+            TreeEntry(name: "lib", hash: "def", isDirectory: true),
+        ]
+        let original = Tree(entries: entries)
+        let encoded = try original.encode()
+        let decoded = try Tree.decode(encoded)
+        XCTAssertEqual(decoded.entries.count, original.entries.count)
+        for (orig, dec) in zip(original.entries, decoded.entries) {
+            XCTAssertEqual(orig.name, dec.name)
+            XCTAssertEqual(orig.hash, dec.hash)
+            XCTAssertEqual(orig.isDirectory, dec.isDirectory)
+        }
+    }
+
+    func testRoundTripManyEntries() throws {
+        let entries = (0..<120).map { i in
+            TreeEntry(name: "item_\(i)", hash: String(format: "%040d", i), isDirectory: i % 3 == 0)
+        }
+        let original = Tree(entries: entries)
+        let encoded = try original.encode()
+        let decoded = try Tree.decode(encoded)
+        XCTAssertEqual(decoded.entries.count, 120)
+        for (orig, dec) in zip(original.entries, decoded.entries) {
+            XCTAssertEqual(orig.name, dec.name)
+            XCTAssertEqual(orig.hash, dec.hash)
+            XCTAssertEqual(orig.isDirectory, dec.isDirectory)
+        }
+    }
+
+    // MARK: - TreeEntry Codable
+
+    func testTreeEntryCodableRoundTrip() throws {
+        let entry = TreeEntry(name: "test.swift", hash: "deadbeef", isDirectory: false)
+        let data = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(TreeEntry.self, from: data)
+        XCTAssertEqual(decoded.name, entry.name)
+        XCTAssertEqual(decoded.hash, entry.hash)
+        XCTAssertEqual(decoded.isDirectory, entry.isDirectory)
+    }
+}

--- a/Tests/VCSTests/VCSEntryTests.swift
+++ b/Tests/VCSTests/VCSEntryTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import VCS
+
+final class VCSEntryTests: XCTestCase {
+    func testVCSRun() {
+        // VCS.run() prints to stdout — verify no crash
+        VCS.run()
+    }
+}

--- a/Tests/VCSTests/VCSTests.swift
+++ b/Tests/VCSTests/VCSTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import VCS
-
-final class VCSTests: XCTestCase {
-    func testExample() throws {
-        XCTAssertTrue(true)
-    }
-}

--- a/Tests/VCSTests/ZlibCompressionTests.swift
+++ b/Tests/VCSTests/ZlibCompressionTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import VCS
+
+final class ZlibCompressionTests: TempDirectoryTestCase {
+    var zlib: ZlibCompression!
+
+    override func setUp() {
+        super.setUp()
+        zlib = ZlibCompression()
+    }
+
+    // MARK: - Name
+
+    func testName() {
+        XCTAssertEqual(zlib.name, "zlib")
+    }
+
+    // MARK: - Compress
+
+    func testCompressProducesSmaller() throws {
+        let repetitive = Data(String(repeating: "abcdefghij", count: 1000).utf8)
+        let compressed = try zlib.compress(repetitive)
+        XCTAssertLessThan(compressed.count, repetitive.count)
+    }
+
+    func testCompressEmptyDataProducesOutput() throws {
+        // On modern Swift, empty Data has non-nil baseAddress
+        // compression_encode_buffer with 0 bytes produces a small zlib header (2 bytes)
+        let compressed = try zlib.compress(Data())
+        XCTAssertGreaterThan(compressed.count, 0)
+    }
+
+    func testCompressProducesNonEmptyOutput() throws {
+        let data = Data([0x42])
+        let compressed = try zlib.compress(data)
+        XCTAssertGreaterThan(compressed.count, 0)
+    }
+
+    // MARK: - Decompress
+
+    func testDecompressInvalidData() throws {
+        // All 0xFF bytes are not valid zlib — decompress returns 0
+        let garbage = Data(repeating: 0xFF, count: 100)
+        XCTAssertThrowsError(try zlib.decompress(garbage))
+    }
+
+    func testDecompressEmptyCompressedData() {
+        // Empty data is not valid zlib — decompress should throw
+        XCTAssertThrowsError(try zlib.decompress(Data())) { error in
+            XCTAssertTrue(error is CompressionError, "Expected CompressionError, got \(error)")
+        }
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripHelloWorld() throws {
+        let data = Data("Hello, World!".utf8)
+        let result = try zlib.decompress(zlib.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    func testRoundTripSmall() throws {
+        let data = Data([0x42])
+        let result = try zlib.decompress(zlib.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    func testRoundTripBinary() throws {
+        // 256 unique bytes — low compression ratio
+        var data = Data(count: 256)
+        for i in 0..<256 { data[i] = UInt8(i) }
+        let result = try zlib.decompress(zlib.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    func testRoundTripShortText() throws {
+        let data = Data("Short text".utf8)
+        let result = try zlib.decompress(zlib.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    func testRoundTripHighEntropyData() throws {
+        // Data that doesn't compress much — buffer is sufficient
+        var data = Data(count: 500)
+        for i in 0..<500 { data[i] = UInt8(i % 256) }
+        let result = try zlib.decompress(zlib.compress(data))
+        XCTAssertEqual(result, data)
+    }
+
+    // MARK: - Decompression buffer limitation
+
+    func testLargeCompressibleDataDecompressBufferLimit() throws {
+        // Highly compressible data: compressed * 10 < original size
+        // Documents that the fixed 10x buffer can cause truncated decompression
+        let data = Data(repeating: 0x00, count: 10000)
+        let compressed = try zlib.compress(data)
+        XCTAssertLessThan(compressed.count * 10, data.count,
+            "Expected compressed*10 < original to demonstrate buffer limitation")
+        let decompressed = try zlib.decompress(compressed)
+        // Decompressed is truncated to buffer size
+        XCTAssertLessThan(decompressed.count, data.count)
+    }
+
+    // MARK: - Determinism
+
+    func testCompressDeterministic() throws {
+        let data = Data("deterministic test input".utf8)
+        let result1 = try zlib.compress(data)
+        let result2 = try zlib.compress(data)
+        XCTAssertEqual(result1, result2)
+    }
+
+    // MARK: - setObjectStore
+
+    func testSetObjectStoreNoOp() throws {
+        let store = makeObjectStore(at: tempDir)
+        zlib.setObjectStore(store)
+        // Verify compression still works after setObjectStore
+        let data = Data("test".utf8)
+        let result = try zlib.decompress(zlib.compress(data))
+        XCTAssertEqual(result, data)
+    }
+}


### PR DESCRIPTION
## Summary

- **283 tests** across 14 test files (13 suites + shared helper), replacing the single placeholder test
- **0 compiler warnings** — fixed 4 warnings (var→let fixes, removed unused variable, replaced always-true type check)
- **10 weak tests strengthened** — added error type validation and functional assertions to previously assertion-free tests
- Coverage: ~98% line, ~99% function, ~94% region

## Test suites

Hash, ObjectType, Blob, Tree, Commit, ObjectStore, Repository, CompressionRegistry, NoCompression, ZlibCompression, LZ4Compression, JPEGHeaderCompression, VCSEntry

## Known bugs documented in tests

1. `ObjectStore.writeBlob` — JPEG tables hash mismatch between stored and computed hashes
2. Zlib/LZ4 — fixed 10x decompression buffer fails on highly compressible data
3. `Hash.init?(hex:)` — crashes on odd-length hex strings (expects even length)

## Test plan

- [x] `swift test` — 283 tests pass, 0 failures, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)