### PR TITLE
perf: reduce filesystem ops in Repository.initialize and ObjectStore.init

### DIFF
--- a/Sources/VCS/Core/ObjectStore.swift
+++ b/Sources/VCS/Core/ObjectStore.swift
@@ -7,8 +7,6 @@ public class ObjectStore {
     public init(repositoryPath: URL, compressionRegistry: CompressionRegistry) {
         self.objectsPath = repositoryPath.appendingPathComponent(".vcs/objects")
         self.compressionRegistry = compressionRegistry
-
-        try? FileManager.default.createDirectory(at: objectsPath, withIntermediateDirectories: true)
     }
 
     private func objectPath(for hash: Hash) -> URL {

--- a/Sources/VCS/Core/Repository.swift
+++ b/Sources/VCS/Core/Repository.swift
@@ -33,6 +33,14 @@ public class Repository {
         loadIgnorePatterns()
     }
 
+    private init(rootPath: URL, vcsPath: URL, objectStore: ObjectStore, compressionRegistry: CompressionRegistry, ignorePatterns: [String]) {
+        self.rootPath = rootPath
+        self.vcsPath = vcsPath
+        self.objectStore = objectStore
+        self.compressionRegistry = compressionRegistry
+        self.ignorePatterns = ignorePatterns
+    }
+
     public static func initialize(at path: URL) throws -> Repository {
         let vcsPath = path.appendingPathComponent(".vcs")
         try FileManager.default.createDirectory(at: vcsPath, withIntermediateDirectories: true)
@@ -42,7 +50,9 @@ public class Repository {
         let headPath = vcsPath.appendingPathComponent("HEAD")
         try "ref: refs/heads/main\n".write(to: headPath, atomically: true, encoding: .utf8)
 
-        return try Repository(path: path)
+        let registry = CompressionRegistry()
+        let objectStore = ObjectStore(repositoryPath: path, compressionRegistry: registry)
+        return Repository(rootPath: path, vcsPath: vcsPath, objectStore: objectStore, compressionRegistry: registry, ignorePatterns: [".vcs"])
     }
 
     private func loadIgnorePatterns() {

--- a/Tests/VCSTests/ObjectStoreTests.swift
+++ b/Tests/VCSTests/ObjectStoreTests.swift
@@ -11,15 +11,6 @@ final class ObjectStoreTests: TempDirectoryTestCase {
         store = ObjectStore(repositoryPath: tempDir, compressionRegistry: registry)
     }
 
-    // MARK: - Init
-
-    func testInitCreatesObjectsDirectory() {
-        let objectsPath = tempDir.appendingPathComponent(".vcs/objects")
-        var isDir: ObjCBool = false
-        XCTAssertTrue(FileManager.default.fileExists(atPath: objectsPath.path, isDirectory: &isDir))
-        XCTAssertTrue(isDir.boolValue)
-    }
-
     // MARK: - Write / Read
 
     func testWriteAndRead() throws {


### PR DESCRIPTION
## Summary
- Remove redundant `createDirectory` call from `ObjectStore.init` — the objects directory is already created by `Repository.initialize()` or already exists for previously-initialized repos.
- Add a private memberwise initializer to `Repository` so `initialize()` can construct the instance directly, skipping the redundant `ObjectStore.init` directory creation and the `loadIgnorePatterns()` call that reads a nonexistent `.vcsignore` on fresh repos.
- Remove the now-invalid `testInitCreatesObjectsDirectory` test that asserted `ObjectStore.init` creates the directory.

## Test plan
- [x] All 418 tests pass (`swift test` — 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)